### PR TITLE
feat: Initialize Go module and Cobra CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-# Binaries
-dockstart
+# Binaries (in root only)
+/dockstart
 *.exe
 *.exe~
 *.dll

--- a/cmd/dockstart/cmd/root.go
+++ b/cmd/dockstart/cmd/root.go
@@ -1,0 +1,87 @@
+// Package cmd contains the CLI commands for dockstart.
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	// Version is set at build time
+	Version = "dev"
+
+	// Flags
+	dryRun bool
+	force  bool
+)
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:   "dockstart <path>",
+	Short: "Generate Docker development environment files",
+	Long: `dockstart analyzes a project directory and generates Docker
+development environment files including:
+
+  - .devcontainer/devcontainer.json
+  - .devcontainer/docker-compose.yml
+  - .devcontainer/Dockerfile
+
+It detects the project's language (Node.js, Go, Python, Rust) and
+any services (PostgreSQL, Redis) to create an optimized dev environment.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: run,
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	rootCmd.Flags().BoolVar(&dryRun, "dry-run", false, "Preview output without writing files")
+	rootCmd.Flags().BoolVar(&force, "force", false, "Overwrite existing files")
+}
+
+func run(cmd *cobra.Command, args []string) error {
+	// Default to current directory if no path provided
+	path := "."
+	if len(args) > 0 {
+		path = args[0]
+	}
+
+	// Resolve to absolute path
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("invalid path: %w", err)
+	}
+
+	// Verify path exists and is a directory
+	info, err := os.Stat(absPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("path does not exist: %s", absPath)
+		}
+		return fmt.Errorf("cannot access path: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("path is not a directory: %s", absPath)
+	}
+
+	fmt.Printf("📂 Analyzing %s...\n", absPath)
+
+	if dryRun {
+		fmt.Println("🔍 Dry run mode - no files will be written")
+	}
+
+	// TODO: Implement detection logic (Issue #3, #4)
+	fmt.Println("   ⏳ Detection not yet implemented")
+
+	// TODO: Implement generation logic (Issue #5, #6, #7)
+	fmt.Println("   ⏳ Generation not yet implemented")
+
+	return nil
+}

--- a/cmd/dockstart/main.go
+++ b/cmd/dockstart/main.go
@@ -1,0 +1,15 @@
+// Package main is the entry point for the dockstart CLI tool.
+// dockstart analyzes a project and generates Docker development environment files.
+package main
+
+import (
+	"os"
+
+	"github.com/jpequegn/dockstart/cmd/dockstart/cmd"
+)
+
+func main() {
+	if err := cmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/jpequegn/dockstart
+
+go 1.25.3
+
+require github.com/spf13/cobra v1.10.2
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
+github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
## Summary

- Initialize `go.mod` with `github.com/jpequegn/dockstart`
- Add Cobra framework for CLI structure
- Create root command with path argument support
- Add `--dry-run` and `--force` flags for future use
- Implement path validation and error handling

## Changes

- `cmd/dockstart/main.go` - Entry point
- `cmd/dockstart/cmd/root.go` - Root command with CLI logic
- `go.mod` / `go.sum` - Dependencies (Cobra)
- `.gitignore` - Fixed to not exclude `cmd/dockstart/` directory

## Testing

```bash
# Build
go build -o dockstart ./cmd/dockstart

# Test help
./dockstart --help

# Test on directory
./dockstart .

# Test error handling
./dockstart /nonexistent
```

## Closes

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)