### PR TITLE
feat: Implement Detector interface and Node.js detector

### DIFF
--- a/internal/detector/detector.go
+++ b/internal/detector/detector.go
@@ -1,0 +1,86 @@
+// Package detector provides language and service detection for projects.
+package detector
+
+import (
+	"github.com/jpequegn/dockstart/internal/models"
+)
+
+// Detector is the interface that all language detectors must implement.
+// Each detector is responsible for identifying a specific language/runtime.
+type Detector interface {
+	// Name returns the detector's identifier (e.g., "node", "go", "python")
+	Name() string
+
+	// Detect analyzes the given path and returns a Detection if the language is found.
+	// Returns nil if the language is not detected, or an error if something went wrong.
+	Detect(path string) (*models.Detection, error)
+}
+
+// DetectorRegistry holds all registered detectors and orchestrates detection.
+type DetectorRegistry struct {
+	detectors []Detector
+}
+
+// NewRegistry creates a new detector registry with default detectors.
+func NewRegistry() *DetectorRegistry {
+	return &DetectorRegistry{
+		detectors: []Detector{
+			NewNodeDetector(),
+			// TODO: Add more detectors (Go, Python, Rust)
+		},
+	}
+}
+
+// Register adds a detector to the registry.
+func (r *DetectorRegistry) Register(d Detector) {
+	r.detectors = append(r.detectors, d)
+}
+
+// DetectAll runs all registered detectors and returns all detections.
+// Results are sorted by confidence (highest first).
+func (r *DetectorRegistry) DetectAll(path string) ([]*models.Detection, error) {
+	var detections []*models.Detection
+
+	for _, detector := range r.detectors {
+		detection, err := detector.Detect(path)
+		if err != nil {
+			// Log error but continue with other detectors
+			continue
+		}
+		if detection != nil {
+			detections = append(detections, detection)
+		}
+	}
+
+	// Sort by confidence (highest first)
+	sortByConfidence(detections)
+
+	return detections, nil
+}
+
+// DetectPrimary runs all detectors and returns the most confident detection.
+// Returns nil if no language is detected.
+func (r *DetectorRegistry) DetectPrimary(path string) (*models.Detection, error) {
+	detections, err := r.DetectAll(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(detections) == 0 {
+		return nil, nil
+	}
+
+	return detections[0], nil
+}
+
+// sortByConfidence sorts detections by confidence score (highest first).
+func sortByConfidence(detections []*models.Detection) {
+	// Simple bubble sort (good enough for small lists)
+	for i := 0; i < len(detections); i++ {
+		for j := i + 1; j < len(detections); j++ {
+			if detections[j].Confidence > detections[i].Confidence {
+				detections[i], detections[j] = detections[j], detections[i]
+			}
+		}
+	}
+}

--- a/internal/detector/node.go
+++ b/internal/detector/node.go
@@ -1,0 +1,192 @@
+package detector
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/jpequegn/dockstart/internal/models"
+)
+
+// NodeDetector detects Node.js projects by analyzing package.json.
+type NodeDetector struct{}
+
+// NewNodeDetector creates a new Node.js detector.
+func NewNodeDetector() *NodeDetector {
+	return &NodeDetector{}
+}
+
+// Name returns the detector identifier.
+func (d *NodeDetector) Name() string {
+	return "node"
+}
+
+// packageJSON represents the structure of a package.json file.
+// We only parse the fields we care about.
+type packageJSON struct {
+	Name            string            `json:"name"`
+	Engines         engines           `json:"engines"`
+	Dependencies    map[string]string `json:"dependencies"`
+	DevDependencies map[string]string `json:"devDependencies"`
+}
+
+type engines struct {
+	Node string `json:"node"`
+}
+
+// Detect analyzes the path for a Node.js project.
+// It looks for package.json and extracts version and service information.
+func (d *NodeDetector) Detect(path string) (*models.Detection, error) {
+	packagePath := filepath.Join(path, "package.json")
+
+	// Check if package.json exists
+	if _, err := os.Stat(packagePath); os.IsNotExist(err) {
+		return nil, nil // Not a Node.js project
+	}
+
+	// Read and parse package.json
+	data, err := os.ReadFile(packagePath)
+	if err != nil {
+		return nil, err
+	}
+
+	var pkg packageJSON
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return nil, err
+	}
+
+	detection := &models.Detection{
+		Language:   "node",
+		Version:    d.extractVersion(pkg),
+		Services:   d.detectServices(pkg),
+		Confidence: d.calculateConfidence(pkg),
+	}
+
+	return detection, nil
+}
+
+// extractVersion extracts the Node.js version from package.json.
+// Priority: engines.node > inferred from dependencies > default
+func (d *NodeDetector) extractVersion(pkg packageJSON) string {
+	if pkg.Engines.Node != "" {
+		// Parse version from engines.node (e.g., ">=18", "^20.0.0", "20.x")
+		return parseVersionConstraint(pkg.Engines.Node)
+	}
+
+	// Default to Node 20 LTS if not specified
+	return "20"
+}
+
+// parseVersionConstraint extracts the major version from a semver constraint.
+// Examples: ">=18" -> "18", "^20.0.0" -> "20", "20.x" -> "20"
+func parseVersionConstraint(constraint string) string {
+	// Match the first number in the constraint
+	re := regexp.MustCompile(`\d+`)
+	match := re.FindString(constraint)
+	if match != "" {
+		return match
+	}
+	return "20" // Default
+}
+
+// detectServices identifies backing services from dependencies.
+func (d *NodeDetector) detectServices(pkg packageJSON) []string {
+	var services []string
+
+	// Merge all dependencies for checking
+	allDeps := make(map[string]string)
+	for k, v := range pkg.Dependencies {
+		allDeps[k] = v
+	}
+	for k, v := range pkg.DevDependencies {
+		allDeps[k] = v
+	}
+
+	// PostgreSQL indicators
+	postgresPackages := []string{"pg", "postgres", "postgresql", "prisma", "@prisma/client", "typeorm", "sequelize", "knex"}
+	if hasAnyDep(allDeps, postgresPackages) {
+		services = append(services, "postgres")
+	}
+
+	// Redis indicators
+	redisPackages := []string{"redis", "ioredis", "@redis/client", "bull", "bullmq"}
+	if hasAnyDep(allDeps, redisPackages) {
+		services = append(services, "redis")
+	}
+
+	return services
+}
+
+// hasAnyDep checks if any of the given package names exist in dependencies.
+func hasAnyDep(deps map[string]string, packages []string) bool {
+	for _, pkg := range packages {
+		if _, exists := deps[pkg]; exists {
+			return true
+		}
+	}
+	return false
+}
+
+// calculateConfidence determines how confident we are in the detection.
+func (d *NodeDetector) calculateConfidence(pkg packageJSON) float64 {
+	confidence := 0.5 // Base confidence for having package.json
+
+	// Higher confidence if engines.node is specified
+	if pkg.Engines.Node != "" {
+		confidence += 0.3
+	}
+
+	// Higher confidence if name is specified
+	if pkg.Name != "" {
+		confidence += 0.1
+	}
+
+	// Higher confidence if dependencies exist
+	if len(pkg.Dependencies) > 0 || len(pkg.DevDependencies) > 0 {
+		confidence += 0.1
+	}
+
+	// Cap at 1.0
+	if confidence > 1.0 {
+		confidence = 1.0
+	}
+
+	return confidence
+}
+
+// GetVSCodeExtensions returns recommended VS Code extensions for Node.js.
+func (d *NodeDetector) GetVSCodeExtensions(pkg packageJSON) []string {
+	extensions := []string{
+		"dbaeumer.vscode-eslint",
+	}
+
+	// Check for TypeScript
+	allDeps := make(map[string]string)
+	for k, v := range pkg.Dependencies {
+		allDeps[k] = v
+	}
+	for k, v := range pkg.DevDependencies {
+		allDeps[k] = v
+	}
+
+	if _, hasTS := allDeps["typescript"]; hasTS {
+		// TypeScript support is built into VS Code, no extra extension needed
+	}
+
+	// Check for Prettier
+	if _, hasPrettier := allDeps["prettier"]; hasPrettier {
+		extensions = append(extensions, "esbenp.prettier-vscode")
+	}
+
+	// Check for Prisma
+	for dep := range allDeps {
+		if strings.Contains(dep, "prisma") {
+			extensions = append(extensions, "Prisma.prisma")
+			break
+		}
+	}
+
+	return extensions
+}

--- a/internal/detector/node_test.go
+++ b/internal/detector/node_test.go
@@ -1,0 +1,274 @@
+package detector
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNodeDetector_Name(t *testing.T) {
+	d := NewNodeDetector()
+	if d.Name() != "node" {
+		t.Errorf("expected name 'node', got '%s'", d.Name())
+	}
+}
+
+func TestNodeDetector_Detect_NoPackageJSON(t *testing.T) {
+	d := NewNodeDetector()
+
+	// Create a temp directory without package.json
+	tmpDir, err := os.MkdirTemp("", "dockstart-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	detection, err := d.Detect(tmpDir)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if detection != nil {
+		t.Error("expected nil detection for non-Node.js project")
+	}
+}
+
+func TestNodeDetector_Detect_BasicPackageJSON(t *testing.T) {
+	d := NewNodeDetector()
+
+	// Create temp directory with basic package.json
+	tmpDir, err := os.MkdirTemp("", "dockstart-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	packageJSON := `{
+		"name": "test-project",
+		"version": "1.0.0"
+	}`
+	if err := os.WriteFile(filepath.Join(tmpDir, "package.json"), []byte(packageJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	detection, err := d.Detect(tmpDir)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if detection == nil {
+		t.Fatal("expected detection, got nil")
+	}
+
+	if detection.Language != "node" {
+		t.Errorf("expected language 'node', got '%s'", detection.Language)
+	}
+	if detection.Version != "20" {
+		t.Errorf("expected default version '20', got '%s'", detection.Version)
+	}
+	if detection.Confidence < 0.5 {
+		t.Errorf("expected confidence >= 0.5, got %f", detection.Confidence)
+	}
+}
+
+func TestNodeDetector_Detect_WithEngines(t *testing.T) {
+	d := NewNodeDetector()
+
+	tmpDir, err := os.MkdirTemp("", "dockstart-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	packageJSON := `{
+		"name": "test-project",
+		"engines": {
+			"node": ">=18.0.0"
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(tmpDir, "package.json"), []byte(packageJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	detection, err := d.Detect(tmpDir)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if detection == nil {
+		t.Fatal("expected detection, got nil")
+	}
+
+	if detection.Version != "18" {
+		t.Errorf("expected version '18', got '%s'", detection.Version)
+	}
+	// Higher confidence when engines is specified
+	if detection.Confidence < 0.8 {
+		t.Errorf("expected confidence >= 0.8 with engines specified, got %f", detection.Confidence)
+	}
+}
+
+func TestNodeDetector_Detect_PostgresService(t *testing.T) {
+	d := NewNodeDetector()
+
+	tmpDir, err := os.MkdirTemp("", "dockstart-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	packageJSON := `{
+		"name": "test-project",
+		"dependencies": {
+			"pg": "^8.11.0",
+			"express": "^4.18.0"
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(tmpDir, "package.json"), []byte(packageJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	detection, err := d.Detect(tmpDir)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if detection == nil {
+		t.Fatal("expected detection, got nil")
+	}
+
+	if !detection.HasService("postgres") {
+		t.Error("expected postgres service to be detected")
+	}
+}
+
+func TestNodeDetector_Detect_RedisService(t *testing.T) {
+	d := NewNodeDetector()
+
+	tmpDir, err := os.MkdirTemp("", "dockstart-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	packageJSON := `{
+		"name": "test-project",
+		"dependencies": {
+			"ioredis": "^5.0.0"
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(tmpDir, "package.json"), []byte(packageJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	detection, err := d.Detect(tmpDir)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if detection == nil {
+		t.Fatal("expected detection, got nil")
+	}
+
+	if !detection.HasService("redis") {
+		t.Error("expected redis service to be detected")
+	}
+}
+
+func TestNodeDetector_Detect_PrismaService(t *testing.T) {
+	d := NewNodeDetector()
+
+	tmpDir, err := os.MkdirTemp("", "dockstart-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	packageJSON := `{
+		"name": "test-project",
+		"dependencies": {
+			"@prisma/client": "^5.0.0"
+		},
+		"devDependencies": {
+			"prisma": "^5.0.0"
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(tmpDir, "package.json"), []byte(packageJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	detection, err := d.Detect(tmpDir)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if detection == nil {
+		t.Fatal("expected detection, got nil")
+	}
+
+	if !detection.HasService("postgres") {
+		t.Error("expected postgres service to be detected for Prisma project")
+	}
+}
+
+func TestNodeDetector_Detect_MultipleServices(t *testing.T) {
+	d := NewNodeDetector()
+
+	tmpDir, err := os.MkdirTemp("", "dockstart-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	packageJSON := `{
+		"name": "test-project",
+		"engines": {
+			"node": "^20.0.0"
+		},
+		"dependencies": {
+			"pg": "^8.11.0",
+			"redis": "^4.0.0",
+			"express": "^4.18.0"
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(tmpDir, "package.json"), []byte(packageJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	detection, err := d.Detect(tmpDir)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if detection == nil {
+		t.Fatal("expected detection, got nil")
+	}
+
+	if detection.Version != "20" {
+		t.Errorf("expected version '20', got '%s'", detection.Version)
+	}
+	if !detection.HasService("postgres") {
+		t.Error("expected postgres service")
+	}
+	if !detection.HasService("redis") {
+		t.Error("expected redis service")
+	}
+	if len(detection.Services) != 2 {
+		t.Errorf("expected 2 services, got %d", len(detection.Services))
+	}
+}
+
+func TestParseVersionConstraint(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{">=18", "18"},
+		{"^20.0.0", "20"},
+		{"~18.17.0", "18"},
+		{"20.x", "20"},
+		{"20", "20"},
+		{">=18.0.0 <21.0.0", "18"},
+		{"", "20"}, // Default
+	}
+
+	for _, test := range tests {
+		result := parseVersionConstraint(test.input)
+		if result != test.expected {
+			t.Errorf("parseVersionConstraint(%q) = %q, expected %q", test.input, result, test.expected)
+		}
+	}
+}

--- a/internal/models/project.go
+++ b/internal/models/project.go
@@ -1,0 +1,48 @@
+// Package models contains shared data structures used across the application.
+package models
+
+// Detection represents the result of analyzing a project directory.
+// It contains information about the detected language, version, and services.
+type Detection struct {
+	// Language is the primary programming language detected (e.g., "node", "go", "python", "rust")
+	Language string
+
+	// Version is the detected or inferred language version (e.g., "20", "1.23", "3.11")
+	Version string
+
+	// Services is a list of detected backing services (e.g., "postgres", "redis")
+	Services []string
+
+	// Confidence is a score from 0.0 to 1.0 indicating detection certainty
+	// Higher values mean more confident detection (e.g., explicit version vs inferred)
+	Confidence float64
+}
+
+// Project represents a fully analyzed project with all its detections.
+type Project struct {
+	// Path is the absolute path to the project directory
+	Path string
+
+	// Name is the project name (derived from directory or package.json/go.mod)
+	Name string
+
+	// Detection contains the primary language detection result
+	Detection *Detection
+}
+
+// HasService checks if a specific service was detected.
+func (d *Detection) HasService(service string) bool {
+	for _, s := range d.Services {
+		if s == service {
+			return true
+		}
+	}
+	return false
+}
+
+// AddService adds a service to the detection if not already present.
+func (d *Detection) AddService(service string) {
+	if !d.HasService(service) {
+		d.Services = append(d.Services, service)
+	}
+}


### PR DESCRIPTION
## Summary

Implement the core detection framework and Node.js detector for analyzing projects.

## Changes

### Models (`internal/models/project.go`)
- `Detection` struct: Language, Version, Services, Confidence
- `Project` struct: Path, Name, Detection
- Helper methods: `HasService()`, `AddService()`

### Detector Interface (`internal/detector/detector.go`)
- `Detector` interface with `Name()` and `Detect()` methods
- `DetectorRegistry` for managing multiple detectors
- `DetectAll()` - returns all detections sorted by confidence
- `DetectPrimary()` - returns highest confidence detection

### Node.js Detector (`internal/detector/node.go`)
- Parses `package.json` for project analysis
- Extracts Node version from `engines.node` (supports `>=18`, `^20.0.0`, etc.)
- Detects PostgreSQL services: `pg`, `prisma`, `typeorm`, `sequelize`, `knex`
- Detects Redis services: `redis`, `ioredis`, `bull`, `bullmq`
- Confidence scoring based on package.json completeness

## Go Concepts Demonstrated

| Concept | Where |
|---------|-------|
| Interfaces | `Detector` interface, multiple implementations |
| JSON unmarshaling | `packageJSON` struct with tags |
| File system ops | `os.Stat`, `os.ReadFile` |
| Regex | Version constraint parsing |
| Table-driven tests | `TestParseVersionConstraint` |

## Testing

```bash
$ go test ./internal/... -v
=== RUN   TestNodeDetector_Name
--- PASS: TestNodeDetector_Name
=== RUN   TestNodeDetector_Detect_NoPackageJSON
--- PASS: TestNodeDetector_Detect_NoPackageJSON
=== RUN   TestNodeDetector_Detect_BasicPackageJSON
--- PASS: TestNodeDetector_Detect_BasicPackageJSON
=== RUN   TestNodeDetector_Detect_WithEngines
--- PASS: TestNodeDetector_Detect_WithEngines
=== RUN   TestNodeDetector_Detect_PostgresService
--- PASS: TestNodeDetector_Detect_PostgresService
=== RUN   TestNodeDetector_Detect_RedisService
--- PASS: TestNodeDetector_Detect_RedisService
=== RUN   TestNodeDetector_Detect_PrismaService
--- PASS: TestNodeDetector_Detect_PrismaService
=== RUN   TestNodeDetector_Detect_MultipleServices
--- PASS: TestNodeDetector_Detect_MultipleServices
=== RUN   TestParseVersionConstraint
--- PASS: TestParseVersionConstraint
PASS
```

## Closes

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)