### PR TITLE
feat: add Python and Rust language detectors

### DIFF
--- a/cmd/dockstart/cmd/root.go
+++ b/cmd/dockstart/cmd/root.go
@@ -91,7 +91,7 @@ func run(cmd *cobra.Command, args []string) error {
 
 	if detection == nil {
 		fmt.Println("   ⚠️  No supported language detected")
-		fmt.Println("   Supported: Node.js (package.json), Go (go.mod)")
+		fmt.Println("   Supported: Node.js (package.json), Go (go.mod), Python (pyproject.toml/requirements.txt), Rust (Cargo.toml)")
 		return nil
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23
 require github.com/spf13/cobra v1.10.2
 
 require (
+	github.com/BurntSushi/toml v1.5.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
+github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=

--- a/internal/detector/detector.go
+++ b/internal/detector/detector.go
@@ -27,7 +27,8 @@ func NewRegistry() *DetectorRegistry {
 		detectors: []Detector{
 			NewNodeDetector(),
 			NewGoDetector(),
-			// TODO: Add more detectors (Python, Rust)
+			NewPythonDetector(),
+			NewRustDetector(),
 		},
 	}
 }

--- a/internal/detector/python_test.go
+++ b/internal/detector/python_test.go
@@ -1,0 +1,376 @@
+package detector
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPythonDetector_Name(t *testing.T) {
+	d := NewPythonDetector()
+	if d.Name() != "python" {
+		t.Errorf("Name() = %v, want python", d.Name())
+	}
+}
+
+func TestPythonDetector_Detect_NoPythonFiles(t *testing.T) {
+	// Create a temporary directory with no Python files
+	tmpDir, err := os.MkdirTemp("", "dockstart-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	d := NewPythonDetector()
+	detection, err := d.Detect(tmpDir)
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+	if detection != nil {
+		t.Error("Expected nil detection for non-Python project")
+	}
+}
+
+func TestPythonDetector_Detect_PyprojectBasic(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "dockstart-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create pyproject.toml
+	pyproject := `
+[project]
+name = "my-python-app"
+requires-python = ">=3.10"
+dependencies = [
+    "fastapi>=0.100.0",
+    "uvicorn>=0.23.0",
+]
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "pyproject.toml"), []byte(pyproject), 0644); err != nil {
+		t.Fatalf("Failed to write pyproject.toml: %v", err)
+	}
+
+	d := NewPythonDetector()
+	detection, err := d.Detect(tmpDir)
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+	if detection == nil {
+		t.Fatal("Expected detection, got nil")
+	}
+
+	if detection.Language != "python" {
+		t.Errorf("Language = %v, want python", detection.Language)
+	}
+	if detection.Version != "3.10" {
+		t.Errorf("Version = %v, want 3.10", detection.Version)
+	}
+	if detection.Confidence < 0.7 {
+		t.Errorf("Confidence = %v, want >= 0.7", detection.Confidence)
+	}
+}
+
+func TestPythonDetector_Detect_PyprojectWithPostgres(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "dockstart-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	pyproject := `
+[project]
+name = "db-app"
+requires-python = ">=3.11"
+dependencies = [
+    "psycopg2-binary>=2.9.0",
+    "sqlalchemy>=2.0.0",
+]
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "pyproject.toml"), []byte(pyproject), 0644); err != nil {
+		t.Fatalf("Failed to write pyproject.toml: %v", err)
+	}
+
+	d := NewPythonDetector()
+	detection, err := d.Detect(tmpDir)
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+
+	if len(detection.Services) != 1 || detection.Services[0] != "postgres" {
+		t.Errorf("Services = %v, want [postgres]", detection.Services)
+	}
+}
+
+func TestPythonDetector_Detect_PyprojectWithRedis(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "dockstart-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	pyproject := `
+[project]
+name = "cache-app"
+requires-python = ">=3.11"
+dependencies = [
+    "redis>=4.0.0",
+    "celery>=5.3.0",
+]
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "pyproject.toml"), []byte(pyproject), 0644); err != nil {
+		t.Fatalf("Failed to write pyproject.toml: %v", err)
+	}
+
+	d := NewPythonDetector()
+	detection, err := d.Detect(tmpDir)
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+
+	// Should detect redis (both redis and celery are redis indicators)
+	if !containsService(detection.Services, "redis") {
+		t.Errorf("Services = %v, should contain redis", detection.Services)
+	}
+}
+
+func TestPythonDetector_Detect_PyprojectMultipleServices(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "dockstart-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	pyproject := `
+[project]
+name = "full-stack-app"
+requires-python = ">=3.11"
+dependencies = [
+    "django>=4.2.0",
+    "psycopg2-binary>=2.9.0",
+    "redis>=4.0.0",
+]
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "pyproject.toml"), []byte(pyproject), 0644); err != nil {
+		t.Fatalf("Failed to write pyproject.toml: %v", err)
+	}
+
+	d := NewPythonDetector()
+	detection, err := d.Detect(tmpDir)
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+
+	if len(detection.Services) != 2 {
+		t.Errorf("Services count = %d, want 2", len(detection.Services))
+	}
+	if !containsService(detection.Services, "postgres") {
+		t.Error("Should detect postgres")
+	}
+	if !containsService(detection.Services, "redis") {
+		t.Error("Should detect redis")
+	}
+}
+
+func TestPythonDetector_Detect_PoetryFormat(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "dockstart-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	pyproject := `
+[tool.poetry]
+name = "poetry-app"
+
+[tool.poetry.dependencies]
+python = "^3.10"
+fastapi = "^0.100.0"
+psycopg2-binary = "^2.9.0"
+
+[tool.poetry.dev-dependencies]
+pytest = "^7.0.0"
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "pyproject.toml"), []byte(pyproject), 0644); err != nil {
+		t.Fatalf("Failed to write pyproject.toml: %v", err)
+	}
+
+	d := NewPythonDetector()
+	detection, err := d.Detect(tmpDir)
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+
+	if detection.Language != "python" {
+		t.Errorf("Language = %v, want python", detection.Language)
+	}
+	if detection.Version != "3.10" {
+		t.Errorf("Version = %v, want 3.10", detection.Version)
+	}
+	if !containsService(detection.Services, "postgres") {
+		t.Error("Should detect postgres from psycopg2-binary")
+	}
+}
+
+func TestPythonDetector_Detect_RequirementsTxt(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "dockstart-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	requirements := `
+# Web framework
+flask>=2.0.0
+gunicorn>=21.0.0
+
+# Database
+psycopg2>=2.9.0
+sqlalchemy>=2.0.0
+
+# Cache
+redis>=4.0.0
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "requirements.txt"), []byte(requirements), 0644); err != nil {
+		t.Fatalf("Failed to write requirements.txt: %v", err)
+	}
+
+	d := NewPythonDetector()
+	detection, err := d.Detect(tmpDir)
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+
+	if detection == nil {
+		t.Fatal("Expected detection, got nil")
+	}
+	if detection.Language != "python" {
+		t.Errorf("Language = %v, want python", detection.Language)
+	}
+	// Default version when not specified
+	if detection.Version != "3.11" {
+		t.Errorf("Version = %v, want 3.11 (default)", detection.Version)
+	}
+	if !containsService(detection.Services, "postgres") {
+		t.Error("Should detect postgres")
+	}
+	if !containsService(detection.Services, "redis") {
+		t.Error("Should detect redis")
+	}
+}
+
+func TestPythonDetector_Detect_PyprojectTakesPrecedence(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "dockstart-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create both files
+	pyproject := `
+[project]
+name = "modern-app"
+requires-python = ">=3.12"
+dependencies = ["fastapi>=0.100.0"]
+`
+	requirements := `
+flask>=2.0.0
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "pyproject.toml"), []byte(pyproject), 0644); err != nil {
+		t.Fatalf("Failed to write pyproject.toml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "requirements.txt"), []byte(requirements), 0644); err != nil {
+		t.Fatalf("Failed to write requirements.txt: %v", err)
+	}
+
+	d := NewPythonDetector()
+	detection, err := d.Detect(tmpDir)
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+
+	// pyproject.toml should take precedence
+	if detection.Version != "3.12" {
+		t.Errorf("Version = %v, want 3.12 (from pyproject.toml)", detection.Version)
+	}
+}
+
+func TestPythonDetector_ParseVersionConstraint(t *testing.T) {
+	d := NewPythonDetector()
+
+	tests := []struct {
+		constraint string
+		want       string
+	}{
+		{">=3.10", "3.10"},
+		{"^3.11", "3.11"},
+		{">=3.9,<4.0", "3.9"},
+		{"~=3.10.0", "3.10"},
+		{"3.11", "3.11"},
+		{"invalid", "3.11"}, // Default
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.constraint, func(t *testing.T) {
+			got := d.parseVersionConstraint(tt.constraint)
+			if got != tt.want {
+				t.Errorf("parseVersionConstraint(%q) = %v, want %v", tt.constraint, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPythonDetector_HighConfidence(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "dockstart-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Full pyproject.toml with all fields
+	pyproject := `
+[project]
+name = "complete-app"
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi>=0.100.0",
+    "uvicorn>=0.23.0",
+]
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "pyproject.toml"), []byte(pyproject), 0644); err != nil {
+		t.Fatalf("Failed to write pyproject.toml: %v", err)
+	}
+
+	d := NewPythonDetector()
+	detection, err := d.Detect(tmpDir)
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+
+	// Should have high confidence with name, version, and dependencies
+	if detection.Confidence < 0.9 {
+		t.Errorf("Confidence = %v, want >= 0.9 for complete pyproject.toml", detection.Confidence)
+	}
+}
+
+func TestPythonDetector_GetVSCodeExtensions(t *testing.T) {
+	d := NewPythonDetector()
+	extensions := d.GetVSCodeExtensions()
+
+	if len(extensions) < 1 {
+		t.Error("Expected at least one VS Code extension")
+	}
+
+	// Should include Python extension
+	found := false
+	for _, ext := range extensions {
+		if ext == "ms-python.python" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("Expected ms-python.python extension")
+	}
+}

--- a/internal/detector/rust.go
+++ b/internal/detector/rust.go
@@ -1,0 +1,190 @@
+package detector
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+	"github.com/jpequegn/dockstart/internal/models"
+)
+
+// RustDetector detects Rust projects by analyzing Cargo.toml.
+type RustDetector struct{}
+
+// NewRustDetector creates a new Rust detector.
+func NewRustDetector() *RustDetector {
+	return &RustDetector{}
+}
+
+// Name returns the detector identifier.
+func (d *RustDetector) Name() string {
+	return "rust"
+}
+
+// cargoTOML represents the structure of a Cargo.toml file.
+// We only parse the fields we care about.
+type cargoTOML struct {
+	Package struct {
+		Name        string `toml:"name"`
+		Version     string `toml:"version"`
+		Edition     string `toml:"edition"`
+		RustVersion string `toml:"rust-version"`
+	} `toml:"package"`
+	Dependencies    map[string]interface{} `toml:"dependencies"`
+	DevDependencies map[string]interface{} `toml:"dev-dependencies"`
+}
+
+// Detect analyzes the path for a Rust project.
+// It looks for Cargo.toml and extracts version and service information.
+func (d *RustDetector) Detect(path string) (*models.Detection, error) {
+	cargoPath := filepath.Join(path, "Cargo.toml")
+
+	// Check if Cargo.toml exists
+	if _, err := os.Stat(cargoPath); os.IsNotExist(err) {
+		return nil, nil // Not a Rust project
+	}
+
+	// Parse Cargo.toml
+	var config cargoTOML
+	if _, err := toml.DecodeFile(cargoPath, &config); err != nil {
+		return nil, err
+	}
+
+	// Collect all dependencies
+	deps := d.collectDependencies(config)
+
+	detection := &models.Detection{
+		Language:   "rust",
+		Version:    d.extractVersion(config),
+		Services:   d.detectServices(deps),
+		Confidence: d.calculateConfidence(config),
+	}
+
+	return detection, nil
+}
+
+// collectDependencies extracts all dependency names from Cargo.toml.
+func (d *RustDetector) collectDependencies(config cargoTOML) []string {
+	var deps []string
+
+	// Add regular dependencies
+	for dep := range config.Dependencies {
+		deps = append(deps, dep)
+	}
+
+	// Add dev dependencies
+	for dep := range config.DevDependencies {
+		deps = append(deps, dep)
+	}
+
+	return deps
+}
+
+// extractVersion extracts the Rust version from Cargo.toml.
+// Priority: rust-version > edition mapping > default
+func (d *RustDetector) extractVersion(config cargoTOML) string {
+	// Try rust-version field first (MSRV - Minimum Supported Rust Version)
+	if config.Package.RustVersion != "" {
+		return config.Package.RustVersion
+	}
+
+	// Map edition to approximate Rust version
+	switch config.Package.Edition {
+	case "2024":
+		return "1.85" // Rust 2024 edition
+	case "2021":
+		return "1.75" // Stable Rust 2021 edition
+	case "2018":
+		return "1.31" // Rust 2018 edition
+	case "2015":
+		return "1.0" // Rust 2015 edition
+	}
+
+	// Default to current stable
+	return "1.75"
+}
+
+// detectServices identifies backing services from Rust dependencies.
+func (d *RustDetector) detectServices(deps []string) []string {
+	var services []string
+
+	// PostgreSQL indicators
+	postgresPackages := []string{
+		"sqlx",
+		"diesel",
+		"tokio-postgres",
+		"postgres",
+		"deadpool-postgres",
+		"sea-orm",
+		"cornucopia",
+	}
+
+	// Redis indicators
+	redisPackages := []string{
+		"redis",
+		"deadpool-redis",
+		"fred",
+		"bb8-redis",
+	}
+
+	for _, dep := range deps {
+		depLower := strings.ToLower(dep)
+
+		// Check PostgreSQL
+		for _, pkg := range postgresPackages {
+			if depLower == pkg {
+				if !containsService(services, "postgres") {
+					services = append(services, "postgres")
+				}
+				break
+			}
+		}
+
+		// Check Redis
+		for _, pkg := range redisPackages {
+			if depLower == pkg {
+				if !containsService(services, "redis") {
+					services = append(services, "redis")
+				}
+				break
+			}
+		}
+	}
+
+	return services
+}
+
+// calculateConfidence determines how confident we are in the detection.
+func (d *RustDetector) calculateConfidence(config cargoTOML) float64 {
+	confidence := 0.7 // Base confidence for having Cargo.toml
+
+	// Higher confidence if package name is specified
+	if config.Package.Name != "" {
+		confidence += 0.1
+	}
+
+	// Higher confidence if edition is specified
+	if config.Package.Edition != "" {
+		confidence += 0.1
+	}
+
+	// Higher confidence if dependencies exist
+	if len(config.Dependencies) > 0 {
+		confidence += 0.1
+	}
+
+	// Cap at 1.0
+	if confidence > 1.0 {
+		confidence = 1.0
+	}
+
+	return confidence
+}
+
+// GetVSCodeExtensions returns recommended VS Code extensions for Rust.
+func (d *RustDetector) GetVSCodeExtensions() []string {
+	return []string{
+		"rust-lang.rust-analyzer",
+	}
+}

--- a/internal/detector/rust_test.go
+++ b/internal/detector/rust_test.go
@@ -1,0 +1,325 @@
+package detector
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRustDetector_Name(t *testing.T) {
+	d := NewRustDetector()
+	if d.Name() != "rust" {
+		t.Errorf("Name() = %v, want rust", d.Name())
+	}
+}
+
+func TestRustDetector_Detect_NoCargoToml(t *testing.T) {
+	// Create a temporary directory with no Cargo.toml
+	tmpDir, err := os.MkdirTemp("", "dockstart-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	d := NewRustDetector()
+	detection, err := d.Detect(tmpDir)
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+	if detection != nil {
+		t.Error("Expected nil detection for non-Rust project")
+	}
+}
+
+func TestRustDetector_Detect_BasicCargoToml(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "dockstart-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create Cargo.toml
+	cargo := `
+[package]
+name = "my-rust-app"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "1.0", features = ["full"] }
+serde = { version = "1.0", features = ["derive"] }
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "Cargo.toml"), []byte(cargo), 0644); err != nil {
+		t.Fatalf("Failed to write Cargo.toml: %v", err)
+	}
+
+	d := NewRustDetector()
+	detection, err := d.Detect(tmpDir)
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+	if detection == nil {
+		t.Fatal("Expected detection, got nil")
+	}
+
+	if detection.Language != "rust" {
+		t.Errorf("Language = %v, want rust", detection.Language)
+	}
+	if detection.Version != "1.75" {
+		t.Errorf("Version = %v, want 1.75 (from edition 2021)", detection.Version)
+	}
+	if detection.Confidence < 0.7 {
+		t.Errorf("Confidence = %v, want >= 0.7", detection.Confidence)
+	}
+}
+
+func TestRustDetector_Detect_WithRustVersion(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "dockstart-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	cargo := `
+[package]
+name = "my-rust-app"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.70"
+
+[dependencies]
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "Cargo.toml"), []byte(cargo), 0644); err != nil {
+		t.Fatalf("Failed to write Cargo.toml: %v", err)
+	}
+
+	d := NewRustDetector()
+	detection, err := d.Detect(tmpDir)
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+
+	// rust-version should take precedence over edition
+	if detection.Version != "1.70" {
+		t.Errorf("Version = %v, want 1.70 (from rust-version)", detection.Version)
+	}
+}
+
+func TestRustDetector_Detect_WithSqlx(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "dockstart-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	cargo := `
+[package]
+name = "db-app"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+sqlx = { version = "0.7", features = ["runtime-tokio", "postgres"] }
+tokio = { version = "1.0", features = ["full"] }
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "Cargo.toml"), []byte(cargo), 0644); err != nil {
+		t.Fatalf("Failed to write Cargo.toml: %v", err)
+	}
+
+	d := NewRustDetector()
+	detection, err := d.Detect(tmpDir)
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+
+	if len(detection.Services) != 1 || detection.Services[0] != "postgres" {
+		t.Errorf("Services = %v, want [postgres]", detection.Services)
+	}
+}
+
+func TestRustDetector_Detect_WithRedis(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "dockstart-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	cargo := `
+[package]
+name = "cache-app"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+redis = "0.24"
+tokio = { version = "1.0", features = ["full"] }
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "Cargo.toml"), []byte(cargo), 0644); err != nil {
+		t.Fatalf("Failed to write Cargo.toml: %v", err)
+	}
+
+	d := NewRustDetector()
+	detection, err := d.Detect(tmpDir)
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+
+	if !containsService(detection.Services, "redis") {
+		t.Errorf("Services = %v, should contain redis", detection.Services)
+	}
+}
+
+func TestRustDetector_Detect_MultipleServices(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "dockstart-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	cargo := `
+[package]
+name = "fullstack-app"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+diesel = { version = "2.1", features = ["postgres"] }
+redis = "0.24"
+tokio = { version = "1.0", features = ["full"] }
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "Cargo.toml"), []byte(cargo), 0644); err != nil {
+		t.Fatalf("Failed to write Cargo.toml: %v", err)
+	}
+
+	d := NewRustDetector()
+	detection, err := d.Detect(tmpDir)
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+
+	if len(detection.Services) != 2 {
+		t.Errorf("Services count = %d, want 2", len(detection.Services))
+	}
+	if !containsService(detection.Services, "postgres") {
+		t.Error("Should detect postgres")
+	}
+	if !containsService(detection.Services, "redis") {
+		t.Error("Should detect redis")
+	}
+}
+
+func TestRustDetector_Detect_SeaORM(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "dockstart-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	cargo := `
+[package]
+name = "sea-app"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+sea-orm = { version = "0.12", features = ["runtime-tokio-native-tls", "sqlx-postgres"] }
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "Cargo.toml"), []byte(cargo), 0644); err != nil {
+		t.Fatalf("Failed to write Cargo.toml: %v", err)
+	}
+
+	d := NewRustDetector()
+	detection, err := d.Detect(tmpDir)
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+
+	if !containsService(detection.Services, "postgres") {
+		t.Errorf("Services = %v, should detect postgres from sea-orm", detection.Services)
+	}
+}
+
+func TestRustDetector_Detect_Edition2018(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "dockstart-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	cargo := `
+[package]
+name = "legacy-app"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "Cargo.toml"), []byte(cargo), 0644); err != nil {
+		t.Fatalf("Failed to write Cargo.toml: %v", err)
+	}
+
+	d := NewRustDetector()
+	detection, err := d.Detect(tmpDir)
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+
+	if detection.Version != "1.31" {
+		t.Errorf("Version = %v, want 1.31 (from edition 2018)", detection.Version)
+	}
+}
+
+func TestRustDetector_HighConfidence(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "dockstart-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Full Cargo.toml with all fields
+	cargo := `
+[package]
+name = "complete-app"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "1.0", features = ["full"] }
+serde = "1.0"
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "Cargo.toml"), []byte(cargo), 0644); err != nil {
+		t.Fatalf("Failed to write Cargo.toml: %v", err)
+	}
+
+	d := NewRustDetector()
+	detection, err := d.Detect(tmpDir)
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+
+	// Should have high confidence with name, edition, and dependencies
+	if detection.Confidence < 0.9 {
+		t.Errorf("Confidence = %v, want >= 0.9 for complete Cargo.toml", detection.Confidence)
+	}
+}
+
+func TestRustDetector_GetVSCodeExtensions(t *testing.T) {
+	d := NewRustDetector()
+	extensions := d.GetVSCodeExtensions()
+
+	if len(extensions) < 1 {
+		t.Error("Expected at least one VS Code extension")
+	}
+
+	// Should include rust-analyzer extension
+	found := false
+	for _, ext := range extensions {
+		if ext == "rust-lang.rust-analyzer" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("Expected rust-lang.rust-analyzer extension")
+	}
+}


### PR DESCRIPTION
## Summary
- Implements Python detector with support for pyproject.toml (PEP 621 + Poetry) and requirements.txt
- Implements Rust detector with support for Cargo.toml
- dockstart now supports all 4 planned languages: Node.js, Go, Python, Rust

## Changes
- `internal/detector/python.go` - Python language detector
- `internal/detector/python_test.go` - 13 unit tests
- `internal/detector/rust.go` - Rust language detector
- `internal/detector/rust_test.go` - 11 unit tests
- `internal/detector/detector.go` - Register new detectors in registry
- `go.mod` - Add github.com/BurntSushi/toml dependency

## Python Detection
| Source | Version Extraction | Service Detection |
|--------|-------------------|-------------------|
| pyproject.toml (PEP 621) | requires-python | psycopg2, asyncpg, sqlalchemy, django, redis, celery |
| pyproject.toml (Poetry) | python dependency | Same as above |
| requirements.txt | Default 3.11 | Same as above |

## Rust Detection
| Feature | Implementation |
|---------|---------------|
| Version | rust-version field > edition mapping > default 1.75 |
| Services | sqlx, diesel, sea-orm, tokio-postgres, redis |
| Edition mapping | 2024→1.85, 2021→1.75, 2018→1.31, 2015→1.0 |

## Test plan
- [x] All 24 new tests pass (13 Python + 11 Rust)
- [x] All existing tests still pass
- [x] CLI correctly detects Python projects
- [x] CLI correctly detects Rust projects

## Demo
```
$ ./dockstart --dry-run /tmp/test-python-project
📂 Analyzing /tmp/test-python-project...
🔍 Detecting project configuration...
   ✅ Detected: python 3.11 (confidence: 100%)
   📦 Services: [postgres redis]

$ ./dockstart --dry-run /tmp/test-rust-project  
📂 Analyzing /tmp/test-rust-project...
🔍 Detecting project configuration...
   ✅ Detected: rust 1.75 (confidence: 100%)
   📦 Services: [postgres]
```

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)