### PR TITLE
feat: create worker sidecar template for docker-compose

### DIFF
--- a/internal/detector/queue_test.go
+++ b/internal/detector/queue_test.go
@@ -1,0 +1,571 @@
+package detector
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestQueueDetection_Node tests queue library detection for Node.js projects.
+func TestQueueDetection_Node(t *testing.T) {
+	tests := []struct {
+		name           string
+		packageJSON    string
+		wantLibraries  []string
+		wantWorkerCmd  string
+	}{
+		{
+			name: "bull queue",
+			packageJSON: `{
+				"name": "test-app",
+				"dependencies": {"bull": "^4.0.0", "express": "^4.18.0"}
+			}`,
+			wantLibraries: []string{"bull"},
+			wantWorkerCmd: "node worker.js",
+		},
+		{
+			name: "bullmq queue",
+			packageJSON: `{
+				"name": "test-app",
+				"dependencies": {"bullmq": "^4.0.0"}
+			}`,
+			wantLibraries: []string{"bullmq"},
+			wantWorkerCmd: "node worker.js",
+		},
+		{
+			name: "bull with worker script",
+			packageJSON: `{
+				"name": "test-app",
+				"dependencies": {"bull": "^4.0.0"},
+				"scripts": {"worker": "node src/worker.js"}
+			}`,
+			wantLibraries: []string{"bull"},
+			wantWorkerCmd: "npm run worker",
+		},
+		{
+			name: "bullmq with start:worker script",
+			packageJSON: `{
+				"name": "test-app",
+				"dependencies": {"bullmq": "^4.0.0"},
+				"scripts": {"start:worker": "node worker.js"}
+			}`,
+			wantLibraries: []string{"bullmq"},
+			wantWorkerCmd: "npm run start:worker",
+		},
+		{
+			name: "bee-queue",
+			packageJSON: `{
+				"name": "test-app",
+				"dependencies": {"bee-queue": "^1.4.0"}
+			}`,
+			wantLibraries: []string{"bee-queue"},
+			wantWorkerCmd: "node worker.js",
+		},
+		{
+			name: "agenda",
+			packageJSON: `{
+				"name": "test-app",
+				"dependencies": {"agenda": "^5.0.0"}
+			}`,
+			wantLibraries: []string{"agenda"},
+			wantWorkerCmd: "node worker.js",
+		},
+		{
+			name: "pg-boss",
+			packageJSON: `{
+				"name": "test-app",
+				"dependencies": {"pg-boss": "^9.0.0"}
+			}`,
+			wantLibraries: []string{"pg-boss"},
+			wantWorkerCmd: "node worker.js",
+		},
+		{
+			name: "no queue library",
+			packageJSON: `{
+				"name": "test-app",
+				"dependencies": {"express": "^4.18.0"}
+			}`,
+			wantLibraries: nil,
+			wantWorkerCmd: "",
+		},
+		{
+			name: "custom worker script name",
+			packageJSON: `{
+				"name": "test-app",
+				"dependencies": {"bull": "^4.0.0"},
+				"scripts": {"my-worker-process": "node worker.js"}
+			}`,
+			wantLibraries: []string{"bull"},
+			wantWorkerCmd: "npm run my-worker-process",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir, err := os.MkdirTemp("", "dockstart-queue-test-*")
+			if err != nil {
+				t.Fatalf("Failed to create temp dir: %v", err)
+			}
+			defer os.RemoveAll(tmpDir)
+
+			if err := os.WriteFile(filepath.Join(tmpDir, "package.json"), []byte(tt.packageJSON), 0644); err != nil {
+				t.Fatalf("Failed to write package.json: %v", err)
+			}
+
+			d := NewNodeDetector()
+			detection, err := d.Detect(tmpDir)
+			if err != nil {
+				t.Fatalf("Detection failed: %v", err)
+			}
+			if detection == nil {
+				t.Fatal("Expected detection, got nil")
+			}
+
+			// Check queue libraries
+			if len(tt.wantLibraries) == 0 {
+				if len(detection.QueueLibraries) != 0 {
+					t.Errorf("QueueLibraries = %v, want empty", detection.QueueLibraries)
+				}
+			} else {
+				for _, lib := range tt.wantLibraries {
+					if !detection.HasQueueLibrary(lib) {
+						t.Errorf("Expected queue library %q to be detected, got %v", lib, detection.QueueLibraries)
+					}
+				}
+			}
+
+			// Check worker command
+			if detection.WorkerCommand != tt.wantWorkerCmd {
+				t.Errorf("WorkerCommand = %q, want %q", detection.WorkerCommand, tt.wantWorkerCmd)
+			}
+
+			// Check NeedsWorker
+			if len(tt.wantLibraries) > 0 && !detection.NeedsWorker() {
+				t.Error("Expected NeedsWorker() to return true")
+			}
+			if len(tt.wantLibraries) == 0 && detection.NeedsWorker() {
+				t.Error("Expected NeedsWorker() to return false")
+			}
+		})
+	}
+}
+
+// TestQueueDetection_Go tests queue library detection for Go projects.
+func TestQueueDetection_Go(t *testing.T) {
+	tests := []struct {
+		name          string
+		goMod         string
+		wantLibraries []string
+		wantWorkerCmd string
+	}{
+		{
+			name: "asynq",
+			goMod: `module github.com/user/myworker
+
+go 1.21
+
+require github.com/hibiken/asynq v0.24.0
+`,
+			wantLibraries: []string{"asynq"},
+			wantWorkerCmd: "./myworker worker",
+		},
+		{
+			name: "machinery",
+			goMod: `module github.com/user/taskrunner
+
+go 1.21
+
+require github.com/RichardKnop/machinery/v2 v2.0.0
+`,
+			wantLibraries: []string{"machinery"},
+			wantWorkerCmd: "./taskrunner worker",
+		},
+		{
+			name: "gocraft-work",
+			goMod: `module github.com/user/jobprocessor
+
+go 1.21
+
+require github.com/gocraft/work v0.5.1
+`,
+			wantLibraries: []string{"gocraft-work"},
+			wantWorkerCmd: "./jobprocessor worker",
+		},
+		{
+			name: "rmq",
+			goMod: `module github.com/user/queueapp
+
+go 1.21
+
+require github.com/adjust/rmq/v5 v5.0.0
+`,
+			wantLibraries: []string{"rmq"},
+			wantWorkerCmd: "./queueapp worker",
+		},
+		{
+			name: "gocelery",
+			goMod: `module github.com/user/celerygo
+
+go 1.21
+
+require github.com/gocelery/gocelery v0.5.1
+`,
+			wantLibraries: []string{"gocelery"},
+			wantWorkerCmd: "./celerygo worker",
+		},
+		{
+			name: "no queue library",
+			goMod: `module github.com/user/webapp
+
+go 1.21
+
+require github.com/gin-gonic/gin v1.9.1
+`,
+			wantLibraries: nil,
+			wantWorkerCmd: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir, err := os.MkdirTemp("", "dockstart-queue-test-*")
+			if err != nil {
+				t.Fatalf("Failed to create temp dir: %v", err)
+			}
+			defer os.RemoveAll(tmpDir)
+
+			if err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte(tt.goMod), 0644); err != nil {
+				t.Fatalf("Failed to write go.mod: %v", err)
+			}
+
+			d := NewGoDetector()
+			detection, err := d.Detect(tmpDir)
+			if err != nil {
+				t.Fatalf("Detection failed: %v", err)
+			}
+			if detection == nil {
+				t.Fatal("Expected detection, got nil")
+			}
+
+			// Check queue libraries
+			if len(tt.wantLibraries) == 0 {
+				if len(detection.QueueLibraries) != 0 {
+					t.Errorf("QueueLibraries = %v, want empty", detection.QueueLibraries)
+				}
+			} else {
+				for _, lib := range tt.wantLibraries {
+					if !detection.HasQueueLibrary(lib) {
+						t.Errorf("Expected queue library %q to be detected, got %v", lib, detection.QueueLibraries)
+					}
+				}
+			}
+
+			// Check worker command
+			if detection.WorkerCommand != tt.wantWorkerCmd {
+				t.Errorf("WorkerCommand = %q, want %q", detection.WorkerCommand, tt.wantWorkerCmd)
+			}
+		})
+	}
+}
+
+// TestQueueDetection_Python tests queue library detection for Python projects.
+func TestQueueDetection_Python(t *testing.T) {
+	tests := []struct {
+		name           string
+		pyprojectTOML  string
+		wantLibraries  []string
+		wantWorkerCmd  string
+	}{
+		{
+			name: "celery",
+			pyprojectTOML: `[project]
+name = "myapp"
+dependencies = ["celery>=5.0.0", "redis>=4.0.0"]
+`,
+			wantLibraries: []string{"celery"},
+			wantWorkerCmd: "celery -A myapp worker",
+		},
+		{
+			name: "rq (Redis Queue)",
+			pyprojectTOML: `[project]
+name = "taskapp"
+dependencies = ["rq>=1.0.0"]
+`,
+			wantLibraries: []string{"rq"},
+			wantWorkerCmd: "rq worker",
+		},
+		{
+			name: "dramatiq",
+			pyprojectTOML: `[project]
+name = "dramaapp"
+dependencies = ["dramatiq>=1.0.0"]
+`,
+			wantLibraries: []string{"dramatiq"},
+			wantWorkerCmd: "dramatiq dramaapp",
+		},
+		{
+			name: "huey",
+			pyprojectTOML: `[project]
+name = "hueyapp"
+dependencies = ["huey>=2.0.0"]
+`,
+			wantLibraries: []string{"huey"},
+			wantWorkerCmd: "huey_consumer hueyapp.huey",
+		},
+		{
+			name: "arq",
+			pyprojectTOML: `[project]
+name = "arqapp"
+dependencies = ["arq>=0.20.0"]
+`,
+			wantLibraries: []string{"arq"},
+			wantWorkerCmd: "arq arqapp.WorkerSettings",
+		},
+		{
+			name: "taskiq",
+			pyprojectTOML: `[project]
+name = "taskiqapp"
+dependencies = ["taskiq>=0.5.0"]
+`,
+			wantLibraries: []string{"taskiq"},
+			wantWorkerCmd: "taskiq worker taskiqapp:broker",
+		},
+		{
+			name: "no queue library",
+			pyprojectTOML: `[project]
+name = "webapp"
+dependencies = ["flask>=2.0.0"]
+`,
+			wantLibraries: nil,
+			wantWorkerCmd: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir, err := os.MkdirTemp("", "dockstart-queue-test-*")
+			if err != nil {
+				t.Fatalf("Failed to create temp dir: %v", err)
+			}
+			defer os.RemoveAll(tmpDir)
+
+			if err := os.WriteFile(filepath.Join(tmpDir, "pyproject.toml"), []byte(tt.pyprojectTOML), 0644); err != nil {
+				t.Fatalf("Failed to write pyproject.toml: %v", err)
+			}
+
+			d := NewPythonDetector()
+			detection, err := d.Detect(tmpDir)
+			if err != nil {
+				t.Fatalf("Detection failed: %v", err)
+			}
+			if detection == nil {
+				t.Fatal("Expected detection, got nil")
+			}
+
+			// Check queue libraries
+			if len(tt.wantLibraries) == 0 {
+				if len(detection.QueueLibraries) != 0 {
+					t.Errorf("QueueLibraries = %v, want empty", detection.QueueLibraries)
+				}
+			} else {
+				for _, lib := range tt.wantLibraries {
+					if !detection.HasQueueLibrary(lib) {
+						t.Errorf("Expected queue library %q to be detected, got %v", lib, detection.QueueLibraries)
+					}
+				}
+			}
+
+			// Check worker command
+			if detection.WorkerCommand != tt.wantWorkerCmd {
+				t.Errorf("WorkerCommand = %q, want %q", detection.WorkerCommand, tt.wantWorkerCmd)
+			}
+		})
+	}
+}
+
+// TestQueueDetection_Python_Requirements tests queue detection with requirements.txt.
+func TestQueueDetection_Python_Requirements(t *testing.T) {
+	tests := []struct {
+		name           string
+		requirements   string
+		wantLibraries  []string
+		wantWorkerCmd  string
+	}{
+		{
+			name:          "celery",
+			requirements:  "celery>=5.0.0\nredis>=4.0.0\n",
+			wantLibraries: []string{"celery"},
+			wantWorkerCmd: "celery -A app worker",
+		},
+		{
+			name:          "rq",
+			requirements:  "rq>=1.0.0\n",
+			wantLibraries: []string{"rq"},
+			wantWorkerCmd: "rq worker",
+		},
+		{
+			name:          "no queue",
+			requirements:  "flask>=2.0.0\n",
+			wantLibraries: nil,
+			wantWorkerCmd: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir, err := os.MkdirTemp("", "dockstart-queue-test-*")
+			if err != nil {
+				t.Fatalf("Failed to create temp dir: %v", err)
+			}
+			defer os.RemoveAll(tmpDir)
+
+			if err := os.WriteFile(filepath.Join(tmpDir, "requirements.txt"), []byte(tt.requirements), 0644); err != nil {
+				t.Fatalf("Failed to write requirements.txt: %v", err)
+			}
+
+			d := NewPythonDetector()
+			detection, err := d.Detect(tmpDir)
+			if err != nil {
+				t.Fatalf("Detection failed: %v", err)
+			}
+			if detection == nil {
+				t.Fatal("Expected detection, got nil")
+			}
+
+			// Check queue libraries
+			if len(tt.wantLibraries) == 0 {
+				if len(detection.QueueLibraries) != 0 {
+					t.Errorf("QueueLibraries = %v, want empty", detection.QueueLibraries)
+				}
+			} else {
+				for _, lib := range tt.wantLibraries {
+					if !detection.HasQueueLibrary(lib) {
+						t.Errorf("Expected queue library %q to be detected, got %v", lib, detection.QueueLibraries)
+					}
+				}
+			}
+
+			// Check worker command
+			if detection.WorkerCommand != tt.wantWorkerCmd {
+				t.Errorf("WorkerCommand = %q, want %q", detection.WorkerCommand, tt.wantWorkerCmd)
+			}
+		})
+	}
+}
+
+// TestQueueDetection_Rust tests queue library detection for Rust projects.
+func TestQueueDetection_Rust(t *testing.T) {
+	tests := []struct {
+		name          string
+		cargoTOML     string
+		wantLibraries []string
+		wantWorkerCmd string
+	}{
+		{
+			name: "sidekiq",
+			cargoTOML: `[package]
+name = "myworker"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+sidekiq = "0.1"
+`,
+			wantLibraries: []string{"sidekiq"},
+			wantWorkerCmd: "./myworker worker",
+		},
+		{
+			name: "apalis",
+			cargoTOML: `[package]
+name = "jobrunner"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+apalis = "0.4"
+`,
+			wantLibraries: []string{"apalis"},
+			wantWorkerCmd: "./jobrunner worker",
+		},
+		{
+			name: "lapin (RabbitMQ)",
+			cargoTOML: `[package]
+name = "rabbitmqworker"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+lapin = "2.0"
+`,
+			wantLibraries: []string{"lapin"},
+			wantWorkerCmd: "./rabbitmqworker worker",
+		},
+		{
+			name: "faktory",
+			cargoTOML: `[package]
+name = "faktoryworker"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+faktory = "0.12"
+`,
+			wantLibraries: []string{"faktory"},
+			wantWorkerCmd: "./faktoryworker worker",
+		},
+		{
+			name: "no queue library",
+			cargoTOML: `[package]
+name = "webapp"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+axum = "0.7"
+`,
+			wantLibraries: nil,
+			wantWorkerCmd: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir, err := os.MkdirTemp("", "dockstart-queue-test-*")
+			if err != nil {
+				t.Fatalf("Failed to create temp dir: %v", err)
+			}
+			defer os.RemoveAll(tmpDir)
+
+			if err := os.WriteFile(filepath.Join(tmpDir, "Cargo.toml"), []byte(tt.cargoTOML), 0644); err != nil {
+				t.Fatalf("Failed to write Cargo.toml: %v", err)
+			}
+
+			d := NewRustDetector()
+			detection, err := d.Detect(tmpDir)
+			if err != nil {
+				t.Fatalf("Detection failed: %v", err)
+			}
+			if detection == nil {
+				t.Fatal("Expected detection, got nil")
+			}
+
+			// Check queue libraries
+			if len(tt.wantLibraries) == 0 {
+				if len(detection.QueueLibraries) != 0 {
+					t.Errorf("QueueLibraries = %v, want empty", detection.QueueLibraries)
+				}
+			} else {
+				for _, lib := range tt.wantLibraries {
+					if !detection.HasQueueLibrary(lib) {
+						t.Errorf("Expected queue library %q to be detected, got %v", lib, detection.QueueLibraries)
+					}
+				}
+			}
+
+			// Check worker command
+			if detection.WorkerCommand != tt.wantWorkerCmd {
+				t.Errorf("WorkerCommand = %q, want %q", detection.WorkerCommand, tt.wantWorkerCmd)
+			}
+		})
+	}
+}

--- a/internal/generator/compose.go
+++ b/internal/generator/compose.go
@@ -27,6 +27,18 @@ type LogSidecarComposeConfig struct {
 	LoggingLibraries []string
 }
 
+// WorkerSidecarConfig holds configuration for the background worker sidecar.
+type WorkerSidecarConfig struct {
+	// Enabled indicates whether to include the worker sidecar
+	Enabled bool
+
+	// Command is the command to start the worker process
+	Command string
+
+	// QueueLibraries is the list of detected queue libraries
+	QueueLibraries []string
+}
+
 // ComposeConfig holds the configuration for generating docker-compose.yml.
 type ComposeConfig struct {
 	// Name is the project name (used for database names, etc.)
@@ -37,6 +49,9 @@ type ComposeConfig struct {
 
 	// LogSidecar holds configuration for the log aggregator sidecar
 	LogSidecar LogSidecarComposeConfig
+
+	// WorkerSidecar holds configuration for the background worker sidecar
+	WorkerSidecar WorkerSidecarConfig
 }
 
 // ComposeGenerator generates docker-compose.yml files.
@@ -100,6 +115,15 @@ func (g *ComposeGenerator) buildConfig(detection *models.Detection, projectName 
 			Enabled:          true,
 			LogFormat:        detection.LogFormat,
 			LoggingLibraries: detection.LoggingLibraries,
+		}
+	}
+
+	// Configure worker sidecar if queue libraries are detected
+	if detection.NeedsWorker() {
+		config.WorkerSidecar = WorkerSidecarConfig{
+			Enabled:        true,
+			Command:        detection.WorkerCommand,
+			QueueLibraries: detection.QueueLibraries,
 		}
 	}
 

--- a/internal/generator/compose_worker_test.go
+++ b/internal/generator/compose_worker_test.go
@@ -1,0 +1,339 @@
+package generator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jpequegn/dockstart/internal/models"
+	"gopkg.in/yaml.v3"
+)
+
+// TestWorkerSidecar tests worker sidecar generation in docker-compose.yml.
+func TestWorkerSidecar(t *testing.T) {
+	tests := []struct {
+		name        string
+		detection   *models.Detection
+		projectName string
+		wantParts   []string
+		dontWant    []string
+	}{
+		{
+			name: "node with bull generates worker",
+			detection: &models.Detection{
+				Language:       "node",
+				Version:        "20",
+				Services:       []string{"redis"},
+				QueueLibraries: []string{"bull"},
+				WorkerCommand:  "npm run worker",
+			},
+			projectName: "node-bull-app",
+			wantParts: []string{
+				"worker:",
+				"command: npm run worker",
+				"depends_on:",
+				"- app",
+				"- redis",
+				"WORKER_CONCURRENCY=2",
+				"NODE_ENV=development",
+				"REDIS_URL=redis://redis:6379",
+				"restart: unless-stopped",
+			},
+			dontWant: []string{
+				"fluent-bit:",
+			},
+		},
+		{
+			name: "python with celery generates worker",
+			detection: &models.Detection{
+				Language:       "python",
+				Version:        "3.11",
+				Services:       []string{"redis", "postgres"},
+				QueueLibraries: []string{"celery"},
+				WorkerCommand:  "celery -A myapp worker",
+			},
+			projectName: "python-celery-app",
+			wantParts: []string{
+				"worker:",
+				"command: celery -A myapp worker",
+				"depends_on:",
+				"- app",
+				"- redis",
+				"- postgres",
+				"DATABASE_URL=postgres://postgres:postgres@postgres:5432/python-celery-app_dev",
+				"restart: unless-stopped",
+			},
+			dontWant: []string{
+				"fluent-bit:",
+			},
+		},
+		{
+			name: "go with asynq generates worker",
+			detection: &models.Detection{
+				Language:       "go",
+				Version:        "1.21",
+				Services:       []string{"redis"},
+				QueueLibraries: []string{"asynq"},
+				WorkerCommand:  "./app worker",
+			},
+			projectName: "go-asynq-app",
+			wantParts: []string{
+				"worker:",
+				"command: ./app worker",
+				"- app",
+				"- redis",
+				"restart: unless-stopped",
+			},
+			dontWant: []string{
+				"fluent-bit:",
+				"postgres:",
+			},
+		},
+		{
+			name: "rust with apalis generates worker",
+			detection: &models.Detection{
+				Language:       "rust",
+				Version:        "1.75",
+				Services:       []string{"postgres"},
+				QueueLibraries: []string{"apalis"},
+				WorkerCommand:  "./myworker worker",
+			},
+			projectName: "rust-apalis-app",
+			wantParts: []string{
+				"worker:",
+				"command: ./myworker worker",
+				"- app",
+				"- postgres",
+				"DATABASE_URL",
+				"restart: unless-stopped",
+			},
+			dontWant: []string{
+				"fluent-bit:",
+				"redis:",
+			},
+		},
+		{
+			name: "no queue library - no worker",
+			detection: &models.Detection{
+				Language:       "node",
+				Version:        "20",
+				Services:       []string{"postgres"},
+				QueueLibraries: nil,
+				WorkerCommand:  "",
+			},
+			projectName: "node-simple-app",
+			wantParts: []string{
+				"app:",
+				"postgres:",
+			},
+			dontWant: []string{
+				"worker:",
+				"WORKER_CONCURRENCY",
+			},
+		},
+		{
+			name: "worker with log sidecar",
+			detection: &models.Detection{
+				Language:         "node",
+				Version:          "20",
+				Services:         []string{"redis"},
+				QueueLibraries:   []string{"bullmq"},
+				WorkerCommand:    "npm run worker",
+				LoggingLibraries: []string{"pino"},
+				LogFormat:        "json",
+			},
+			projectName: "node-full-app",
+			wantParts: []string{
+				"worker:",
+				"command: npm run worker",
+				"fluent-bit:",
+				"tag: worker.node-full-app",
+				"tag: app.node-full-app",
+			},
+			dontWant: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewComposeGenerator()
+			content, err := g.GenerateContent(tt.detection, tt.projectName)
+			if err != nil {
+				t.Fatalf("GenerateContent failed: %v", err)
+			}
+
+			contentStr := string(content)
+
+			// Check expected parts are present
+			for _, want := range tt.wantParts {
+				if !strings.Contains(contentStr, want) {
+					t.Errorf("Expected content to contain %q, but it doesn't.\nContent:\n%s", want, contentStr)
+				}
+			}
+
+			// Check unwanted parts are absent
+			for _, dontWant := range tt.dontWant {
+				if strings.Contains(contentStr, dontWant) {
+					t.Errorf("Expected content NOT to contain %q, but it does.\nContent:\n%s", dontWant, contentStr)
+				}
+			}
+		})
+	}
+}
+
+// TestWorkerSidecar_ValidYAML tests that generated compose files are valid YAML.
+func TestWorkerSidecar_ValidYAML(t *testing.T) {
+	tests := []struct {
+		name        string
+		detection   *models.Detection
+		projectName string
+	}{
+		{
+			name: "worker with redis",
+			detection: &models.Detection{
+				Language:       "node",
+				Version:        "20",
+				Services:       []string{"redis"},
+				QueueLibraries: []string{"bull"},
+				WorkerCommand:  "npm run worker",
+			},
+			projectName: "test-app",
+		},
+		{
+			name: "worker with postgres and redis",
+			detection: &models.Detection{
+				Language:       "python",
+				Version:        "3.11",
+				Services:       []string{"postgres", "redis"},
+				QueueLibraries: []string{"celery"},
+				WorkerCommand:  "celery -A app worker",
+			},
+			projectName: "celery-app",
+		},
+		{
+			name: "worker with log sidecar",
+			detection: &models.Detection{
+				Language:         "node",
+				Version:          "20",
+				Services:         []string{"redis"},
+				QueueLibraries:   []string{"bullmq"},
+				WorkerCommand:    "npm run worker",
+				LoggingLibraries: []string{"pino"},
+				LogFormat:        "json",
+			},
+			projectName: "full-stack-app",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewComposeGenerator()
+			content, err := g.GenerateContent(tt.detection, tt.projectName)
+			if err != nil {
+				t.Fatalf("GenerateContent failed: %v", err)
+			}
+
+			// Try to parse as YAML
+			var parsed map[string]interface{}
+			if err := yaml.Unmarshal(content, &parsed); err != nil {
+				t.Errorf("Generated content is not valid YAML: %v\nContent:\n%s", err, string(content))
+			}
+
+			// Verify worker service exists in parsed YAML
+			if services, ok := parsed["services"].(map[string]interface{}); ok {
+				if _, hasWorker := services["worker"]; !hasWorker {
+					t.Error("Expected 'worker' service in parsed YAML")
+				}
+			} else {
+				t.Error("Expected 'services' key in parsed YAML")
+			}
+		})
+	}
+}
+
+// TestWorkerSidecar_DependsOn tests that worker depends_on is correctly ordered.
+func TestWorkerSidecar_DependsOn(t *testing.T) {
+	detection := &models.Detection{
+		Language:       "node",
+		Version:        "20",
+		Services:       []string{"postgres", "redis"},
+		QueueLibraries: []string{"bull"},
+		WorkerCommand:  "npm run worker",
+	}
+
+	g := NewComposeGenerator()
+	content, err := g.GenerateContent(detection, "test-app")
+	if err != nil {
+		t.Fatalf("GenerateContent failed: %v", err)
+	}
+
+	// Parse as YAML
+	var parsed map[string]interface{}
+	if err := yaml.Unmarshal(content, &parsed); err != nil {
+		t.Fatalf("Failed to parse YAML: %v", err)
+	}
+
+	services := parsed["services"].(map[string]interface{})
+	worker := services["worker"].(map[string]interface{})
+	dependsOn := worker["depends_on"].([]interface{})
+
+	// Check that app is first in depends_on
+	if len(dependsOn) < 1 || dependsOn[0] != "app" {
+		t.Errorf("Expected 'app' to be first in depends_on, got %v", dependsOn)
+	}
+
+	// Check that all services are in depends_on
+	expectedDeps := map[string]bool{"app": false, "postgres": false, "redis": false}
+	for _, dep := range dependsOn {
+		if depStr, ok := dep.(string); ok {
+			expectedDeps[depStr] = true
+		}
+	}
+	for dep, found := range expectedDeps {
+		if !found {
+			t.Errorf("Expected %q to be in depends_on", dep)
+		}
+	}
+}
+
+// TestWorkerSidecar_BuildContext tests that worker uses same Dockerfile as app.
+func TestWorkerSidecar_BuildContext(t *testing.T) {
+	detection := &models.Detection{
+		Language:       "go",
+		Version:        "1.21",
+		Services:       []string{"redis"},
+		QueueLibraries: []string{"asynq"},
+		WorkerCommand:  "./app worker",
+	}
+
+	g := NewComposeGenerator()
+	content, err := g.GenerateContent(detection, "test-app")
+	if err != nil {
+		t.Fatalf("GenerateContent failed: %v", err)
+	}
+
+	// Parse as YAML
+	var parsed map[string]interface{}
+	if err := yaml.Unmarshal(content, &parsed); err != nil {
+		t.Fatalf("Failed to parse YAML: %v", err)
+	}
+
+	services := parsed["services"].(map[string]interface{})
+
+	// Get app build config
+	app := services["app"].(map[string]interface{})
+	appBuild := app["build"].(map[string]interface{})
+
+	// Get worker build config
+	worker := services["worker"].(map[string]interface{})
+	workerBuild := worker["build"].(map[string]interface{})
+
+	// Verify both use same build context and dockerfile
+	if appBuild["context"] != workerBuild["context"] {
+		t.Errorf("Expected worker build context to match app, got app=%v worker=%v",
+			appBuild["context"], workerBuild["context"])
+	}
+	if appBuild["dockerfile"] != workerBuild["dockerfile"] {
+		t.Errorf("Expected worker dockerfile to match app, got app=%v worker=%v",
+			appBuild["dockerfile"], workerBuild["dockerfile"])
+	}
+}

--- a/internal/generator/templates/docker-compose.yml.tmpl
+++ b/internal/generator/templates/docker-compose.yml.tmpl
@@ -41,6 +41,43 @@ services:
         tag: app.{{.Name}}
         fluentd-async: "true"
 {{- end}}
+{{- if .WorkerSidecar.Enabled}}
+
+  # Background worker process
+  # Uses same Dockerfile as app but with different command
+  worker:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    volumes:
+      - ..:/workspace:cached
+    command: {{.WorkerSidecar.Command}}
+    depends_on:
+      - app
+{{- range .Services}}
+      - {{.Name}}
+{{- end}}
+    environment:
+      - WORKER_CONCURRENCY=2
+      - NODE_ENV=development
+{{- range .Services}}
+{{- if eq .Name "postgres"}}
+      - DATABASE_URL=postgres://postgres:postgres@postgres:5432/{{$.Name}}_dev
+{{- end}}
+{{- if eq .Name "redis"}}
+      - REDIS_URL=redis://redis:6379
+{{- end}}
+{{- end}}
+    restart: unless-stopped
+{{- if $.LogSidecar.Enabled}}
+    logging:
+      driver: fluentd
+      options:
+        fluentd-address: localhost:24224
+        tag: worker.{{$.Name}}
+        fluentd-async: "true"
+{{- end}}
+{{- end}}
 {{range .Services}}
 
   # {{.Name}} service

--- a/internal/models/project.go
+++ b/internal/models/project.go
@@ -24,6 +24,14 @@ type Detection struct {
 	// LogFormat indicates the detected or inferred log format
 	// Values: "json", "text", "unknown"
 	LogFormat string
+
+	// QueueLibraries is a list of detected job queue/worker libraries
+	// (e.g., "bull", "bullmq" for Node.js, "celery" for Python)
+	QueueLibraries []string
+
+	// WorkerCommand is the detected or inferred command to start the worker
+	// (e.g., "npm run worker", "celery -A app worker")
+	WorkerCommand string
 }
 
 // Project represents a fully analyzed project with all its detections.
@@ -75,4 +83,26 @@ func (d *Detection) AddLoggingLibrary(library string) {
 // HasStructuredLogging returns true if any structured logging library was detected.
 func (d *Detection) HasStructuredLogging() bool {
 	return len(d.LoggingLibraries) > 0
+}
+
+// HasQueueLibrary checks if a specific queue library was detected.
+func (d *Detection) HasQueueLibrary(library string) bool {
+	for _, l := range d.QueueLibraries {
+		if l == library {
+			return true
+		}
+	}
+	return false
+}
+
+// AddQueueLibrary adds a queue library to the detection if not already present.
+func (d *Detection) AddQueueLibrary(library string) {
+	if !d.HasQueueLibrary(library) {
+		d.QueueLibraries = append(d.QueueLibraries, library)
+	}
+}
+
+// NeedsWorker returns true if any queue library was detected that requires a worker.
+func (d *Detection) NeedsWorker() bool {
+	return len(d.QueueLibraries) > 0
 }


### PR DESCRIPTION
## Summary

- Add `WorkerSidecarConfig` struct to compose generator
- Update compose template to generate worker service when queue libraries are detected
- Worker service uses same Dockerfile as app with different `command:`

## Worker Service Features

- **Same image pattern**: Uses same Dockerfile as app, just different command
- **Proper dependency ordering**: Depends on `app` and all detected services
- **Environment variables**: Includes `WORKER_CONCURRENCY`, `NODE_ENV`, plus database/redis URLs
- **Restart policy**: Uses `unless-stopped` for resilience
- **Log sidecar integration**: When logging libraries detected, worker also sends logs to Fluent Bit

## Example Output

```yaml
  worker:
    build:
      context: ..
      dockerfile: .devcontainer/Dockerfile
    volumes:
      - ..:/workspace:cached
    command: npm run worker
    depends_on:
      - app
      - redis
    environment:
      - WORKER_CONCURRENCY=2
      - NODE_ENV=development
      - REDIS_URL=redis://redis:6379
    restart: unless-stopped
```

## Test plan

- [x] All existing tests pass
- [x] New worker sidecar tests pass (10 test cases)
- [x] `go build ./...` succeeds
- [x] `go test ./...` passes

**Note**: This PR includes changes from #70 (queue library detection) as a merge since it's a dependency.

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)