### PR TITLE
feat: add file processor sidecar to docker-compose generation

### DIFF
--- a/internal/generator/compose_fileprocessor_test.go
+++ b/internal/generator/compose_fileprocessor_test.go
@@ -1,0 +1,328 @@
+package generator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jpequegn/dockstart/internal/models"
+)
+
+// TestComposeGenerator_FileProcessorSidecar tests file processor sidecar generation.
+func TestComposeGenerator_FileProcessorSidecar(t *testing.T) {
+	gen := NewComposeGenerator()
+	detection := &models.Detection{
+		Language:            "node",
+		Version:             "20",
+		Services:            []string{},
+		FileUploadLibraries: []string{"multer"},
+		UploadPath:          "/uploads",
+	}
+
+	content, err := gen.GenerateContent(detection, "upload-app")
+	if err != nil {
+		t.Fatalf("GenerateContent() error = %v", err)
+	}
+
+	yaml := string(content)
+
+	// Check file processor service is included
+	expectedParts := []string{
+		"file-processor:",
+		"dockerfile: Dockerfile.processor",
+		"uploads:/uploads",
+		"PENDING_PATH=/uploads/pending",
+		"PROCESSING_PATH=/uploads/processing",
+		"PROCESSED_PATH=/uploads/processed",
+		"FAILED_PATH=/uploads/failed",
+		"POLL_INTERVAL=5",
+		"MAX_FILE_SIZE=52428800",
+		"RETRY_COUNT=3",
+		"NOTIFY_METHOD=file",
+		"deploy:",
+		"resources:",
+		"limits:",
+		"memory: 512M",
+		"cpus: '0.5'",
+		"restart: unless-stopped",
+		"volumes:",
+		"uploads:",
+	}
+
+	for _, part := range expectedParts {
+		if !strings.Contains(yaml, part) {
+			t.Errorf("YAML should contain %q for file processor sidecar, got:\n%s", part, yaml)
+		}
+	}
+}
+
+// TestComposeGenerator_FileProcessorSidecar_AppVolume tests that app service gets uploads volume.
+func TestComposeGenerator_FileProcessorSidecar_AppVolume(t *testing.T) {
+	gen := NewComposeGenerator()
+	detection := &models.Detection{
+		Language:            "python",
+		Version:             "3.11",
+		Services:            []string{},
+		FileUploadLibraries: []string{"python-multipart"},
+		UploadPath:          "/data/uploads",
+	}
+
+	content, err := gen.GenerateContent(detection, "py-upload")
+	if err != nil {
+		t.Fatalf("GenerateContent() error = %v", err)
+	}
+
+	yaml := string(content)
+
+	// Check app service has uploads volume
+	if !strings.Contains(yaml, "- uploads:/uploads") {
+		t.Errorf("App service should have uploads volume, got:\n%s", yaml)
+	}
+}
+
+// TestComposeGenerator_FileProcessorSidecar_EnvironmentVars tests app environment variables.
+func TestComposeGenerator_FileProcessorSidecar_EnvironmentVars(t *testing.T) {
+	gen := NewComposeGenerator()
+	detection := &models.Detection{
+		Language:            "node",
+		Version:             "20",
+		Services:            []string{},
+		FileUploadLibraries: []string{"formidable"},
+	}
+
+	content, err := gen.GenerateContent(detection, "env-test")
+	if err != nil {
+		t.Fatalf("GenerateContent() error = %v", err)
+	}
+
+	yaml := string(content)
+
+	// Check environment variables for app service
+	expectedEnvVars := []string{
+		"UPLOAD_PATH=/uploads/pending",
+		"PROCESSED_PATH=/uploads/processed",
+		"FAILED_PATH=/uploads/failed",
+	}
+
+	for _, envVar := range expectedEnvVars {
+		if !strings.Contains(yaml, envVar) {
+			t.Errorf("App should have environment variable %q, got:\n%s", envVar, yaml)
+		}
+	}
+}
+
+// TestComposeGenerator_FileProcessorSidecar_NotGenerated tests sidecar not generated without upload libraries.
+func TestComposeGenerator_FileProcessorSidecar_NotGenerated(t *testing.T) {
+	gen := NewComposeGenerator()
+	detection := &models.Detection{
+		Language:            "go",
+		Version:             "1.23",
+		Services:            []string{"postgres"},
+		FileUploadLibraries: []string{}, // No file upload libraries
+	}
+
+	content, err := gen.GenerateContent(detection, "no-uploads")
+	if err != nil {
+		t.Fatalf("GenerateContent() error = %v", err)
+	}
+
+	yaml := string(content)
+
+	// Check file processor service is NOT included
+	unwantedParts := []string{
+		"file-processor:",
+		"Dockerfile.processor",
+		"PENDING_PATH",
+		"PROCESSING_PATH",
+		"PROCESSED_PATH",
+		"FAILED_PATH",
+	}
+
+	for _, part := range unwantedParts {
+		if strings.Contains(yaml, part) {
+			t.Errorf("YAML should NOT contain %q when no upload libraries detected, got:\n%s", part, yaml)
+		}
+	}
+}
+
+// TestComposeGenerator_FileProcessorSidecar_WithOtherServices tests file processor with postgres/redis.
+func TestComposeGenerator_FileProcessorSidecar_WithOtherServices(t *testing.T) {
+	gen := NewComposeGenerator()
+	detection := &models.Detection{
+		Language:            "node",
+		Version:             "20",
+		Services:            []string{"postgres", "redis"},
+		FileUploadLibraries: []string{"multer"},
+		UploadPath:          "/uploads",
+	}
+
+	content, err := gen.GenerateContent(detection, "full-stack")
+	if err != nil {
+		t.Fatalf("GenerateContent() error = %v", err)
+	}
+
+	yaml := string(content)
+
+	// Check all services are present
+	expectedParts := []string{
+		// Postgres
+		"postgres:",
+		"postgres:16-alpine",
+		"DATABASE_URL",
+		// Redis
+		"redis:",
+		"redis:7-alpine",
+		"REDIS_URL",
+		// File processor
+		"file-processor:",
+		"Dockerfile.processor",
+		"PENDING_PATH",
+		// Volumes
+		"volumes:",
+		"postgres-data:",
+		"redis-data:",
+		"uploads:",
+	}
+
+	for _, part := range expectedParts {
+		if !strings.Contains(yaml, part) {
+			t.Errorf("YAML should contain %q, got:\n%s", part, yaml)
+		}
+	}
+}
+
+// TestComposeGenerator_FileProcessorSidecar_WithWorker tests file processor with worker sidecar.
+func TestComposeGenerator_FileProcessorSidecar_WithWorker(t *testing.T) {
+	gen := NewComposeGenerator()
+	detection := &models.Detection{
+		Language:            "node",
+		Version:             "20",
+		Services:            []string{"redis"},
+		FileUploadLibraries: []string{"multer"},
+		QueueLibraries:      []string{"bullmq"},
+		WorkerCommand:       "npm run worker",
+	}
+
+	content, err := gen.GenerateContent(detection, "worker-upload")
+	if err != nil {
+		t.Fatalf("GenerateContent() error = %v", err)
+	}
+
+	yaml := string(content)
+
+	// Check worker also gets upload environment variables
+	expectedParts := []string{
+		"worker:",
+		"npm run worker",
+		"UPLOAD_PATH=/uploads/pending",
+		"PROCESSED_PATH=/uploads/processed",
+		"file-processor:",
+	}
+
+	for _, part := range expectedParts {
+		if !strings.Contains(yaml, part) {
+			t.Errorf("YAML should contain %q, got:\n%s", part, yaml)
+		}
+	}
+
+	// Worker should also get uploads volume
+	// Count occurrences of uploads:/uploads to verify both app and worker have it
+	volumeCount := strings.Count(yaml, "uploads:/uploads")
+	if volumeCount < 2 {
+		t.Errorf("Both app and worker should have uploads volume, found %d occurrences", volumeCount)
+	}
+}
+
+// TestBuildComposeConfig_FileProcessorSidecar tests buildConfig includes file processor config.
+func TestBuildComposeConfig_FileProcessorSidecar(t *testing.T) {
+	gen := NewComposeGenerator()
+
+	detection := &models.Detection{
+		Language:            "node",
+		Version:             "20",
+		Services:            []string{},
+		FileUploadLibraries: []string{"multer", "sharp"},
+		UploadPath:          "/custom/uploads",
+	}
+
+	config := gen.buildConfig(detection, "upload-app")
+
+	// Verify file processor sidecar config
+	if !config.FileProcessorSidecar.Enabled {
+		t.Error("FileProcessorSidecar.Enabled should be true")
+	}
+	if config.FileProcessorSidecar.UploadPath != "/custom/uploads" {
+		t.Errorf("FileProcessorSidecar.UploadPath = %v, want /custom/uploads", config.FileProcessorSidecar.UploadPath)
+	}
+	if len(config.FileProcessorSidecar.FileUploadLibraries) != 2 {
+		t.Errorf("FileProcessorSidecar.FileUploadLibraries count = %d, want 2", len(config.FileProcessorSidecar.FileUploadLibraries))
+	}
+	if !config.FileProcessorSidecar.ProcessImages {
+		t.Error("FileProcessorSidecar.ProcessImages should be true by default")
+	}
+	if config.FileProcessorSidecar.MemoryLimit != "512M" {
+		t.Errorf("FileProcessorSidecar.MemoryLimit = %v, want 512M", config.FileProcessorSidecar.MemoryLimit)
+	}
+	if config.FileProcessorSidecar.CPULimit != "0.5" {
+		t.Errorf("FileProcessorSidecar.CPULimit = %v, want 0.5", config.FileProcessorSidecar.CPULimit)
+	}
+}
+
+// TestBuildComposeConfig_FileProcessorSidecar_DefaultUploadPath tests default upload path.
+func TestBuildComposeConfig_FileProcessorSidecar_DefaultUploadPath(t *testing.T) {
+	gen := NewComposeGenerator()
+
+	detection := &models.Detection{
+		Language:            "python",
+		Version:             "3.11",
+		FileUploadLibraries: []string{"python-multipart"},
+		UploadPath:          "", // Empty, should default to /uploads
+	}
+
+	config := gen.buildConfig(detection, "default-path-app")
+
+	if config.FileProcessorSidecar.UploadPath != "/uploads" {
+		t.Errorf("FileProcessorSidecar.UploadPath = %v, want /uploads (default)", config.FileProcessorSidecar.UploadPath)
+	}
+}
+
+// TestBuildComposeConfig_NoFileProcessorSidecar tests buildConfig without upload libraries.
+func TestBuildComposeConfig_NoFileProcessorSidecar(t *testing.T) {
+	gen := NewComposeGenerator()
+
+	detection := &models.Detection{
+		Language:            "rust",
+		Version:             "1.75",
+		Services:            []string{"redis"},
+		FileUploadLibraries: []string{},
+	}
+
+	config := gen.buildConfig(detection, "no-upload-app")
+
+	// Verify file processor sidecar is NOT enabled
+	if config.FileProcessorSidecar.Enabled {
+		t.Error("FileProcessorSidecar.Enabled should be false when no upload libraries")
+	}
+}
+
+// TestComposeGenerator_FileProcessorSidecar_DependsOnApp tests file-processor depends_on app.
+func TestComposeGenerator_FileProcessorSidecar_DependsOnApp(t *testing.T) {
+	gen := NewComposeGenerator()
+	detection := &models.Detection{
+		Language:            "node",
+		Version:             "20",
+		Services:            []string{},
+		FileUploadLibraries: []string{"multer"},
+	}
+
+	content, err := gen.GenerateContent(detection, "deps-test")
+	if err != nil {
+		t.Fatalf("GenerateContent() error = %v", err)
+	}
+
+	yaml := string(content)
+
+	// Check file-processor has depends_on app
+	if !strings.Contains(yaml, "depends_on:") {
+		t.Error("file-processor should have depends_on")
+	}
+}

--- a/internal/generator/templates/docker-compose.yml.tmpl
+++ b/internal/generator/templates/docker-compose.yml.tmpl
@@ -9,6 +9,9 @@ services:
       dockerfile: .devcontainer/Dockerfile
     volumes:
       - ..:/workspace:cached
+{{- if .FileProcessorSidecar.Enabled}}
+      - uploads:/uploads
+{{- end}}
     command: sleep infinity
 {{- if or .Services .LogSidecar.Enabled}}
     depends_on:
@@ -19,7 +22,7 @@ services:
       - fluent-bit
 {{- end}}
 {{- end}}
-{{- if or .Services .LogSidecar.Enabled}}
+{{- if or .Services .LogSidecar.Enabled .FileProcessorSidecar.Enabled}}
     environment:
 {{- range .Services}}
 {{- if eq .Name "postgres"}}
@@ -31,6 +34,11 @@ services:
 {{- end}}
 {{- if .LogSidecar.Enabled}}
       - LOG_LEVEL=debug
+{{- end}}
+{{- if .FileProcessorSidecar.Enabled}}
+      - UPLOAD_PATH=/uploads/pending
+      - PROCESSED_PATH=/uploads/processed
+      - FAILED_PATH=/uploads/failed
 {{- end}}
 {{- end}}
 {{- if .LogSidecar.Enabled}}
@@ -51,6 +59,9 @@ services:
       dockerfile: .devcontainer/Dockerfile
     volumes:
       - ..:/workspace:cached
+{{- if $.FileProcessorSidecar.Enabled}}
+      - uploads:/uploads
+{{- end}}
     command: {{.WorkerSidecar.Command}}
     depends_on:
       - app
@@ -67,6 +78,11 @@ services:
 {{- if eq .Name "redis"}}
       - REDIS_URL=redis://redis:6379
 {{- end}}
+{{- end}}
+{{- if $.FileProcessorSidecar.Enabled}}
+      - UPLOAD_PATH=/uploads/pending
+      - PROCESSED_PATH=/uploads/processed
+      - FAILED_PATH=/uploads/failed
 {{- end}}
     restart: unless-stopped
 {{- if $.LogSidecar.Enabled}}
@@ -116,7 +132,35 @@ services:
       - "24224:24224"
       - "24224:24224/udp"
 {{- end}}
-{{- if or .Services .LogSidecar.Enabled}}
+{{- if .FileProcessorSidecar.Enabled}}
+
+  # File processor sidecar
+  # Processes uploaded files (resize images, extract text, generate thumbnails)
+  file-processor:
+    build:
+      context: .
+      dockerfile: Dockerfile.processor
+    volumes:
+      - uploads:/uploads
+    depends_on:
+      - app
+    environment:
+      - PENDING_PATH=/uploads/pending
+      - PROCESSING_PATH=/uploads/processing
+      - PROCESSED_PATH=/uploads/processed
+      - FAILED_PATH=/uploads/failed
+      - POLL_INTERVAL=5
+      - MAX_FILE_SIZE=52428800
+      - RETRY_COUNT=3
+      - NOTIFY_METHOD=file
+    deploy:
+      resources:
+        limits:
+          memory: {{.FileProcessorSidecar.MemoryLimit}}
+          cpus: '{{.FileProcessorSidecar.CPULimit}}'
+    restart: unless-stopped
+{{- end}}
+{{- if or .Services .LogSidecar.Enabled .BackupSidecar.Enabled .FileProcessorSidecar.Enabled}}
 
 volumes:
 {{- range .Services}}
@@ -132,6 +176,9 @@ volumes:
 {{- end}}
 {{- if .BackupSidecar.Enabled}}
   backups:
+{{- end}}
+{{- if .FileProcessorSidecar.Enabled}}
+  uploads:
 {{- end}}
 {{- end}}
 {{- if .BackupSidecar.Enabled}}


### PR DESCRIPTION
## Summary

Implements GitHub issue #46 - update compose generator for file processor sidecar.

- Add `FileProcessorSidecarComposeConfig` struct with upload path, processing capabilities, and resource limits
- Update `docker-compose.yml.tmpl` to generate file-processor service when upload libraries detected
- Add shared `uploads` volume between app, worker, and file-processor services
- Add environment variables for upload paths (`UPLOAD_PATH`, `PROCESSED_PATH`, `FAILED_PATH`)
- Add deploy resource limits for the processor container (512M memory, 0.5 CPU)

## Generated Output Example

When file upload libraries (multer, formidable, etc.) are detected:

```yaml
services:
  app:
    volumes:
      - uploads:/uploads
    environment:
      - UPLOAD_PATH=/uploads/pending
      - PROCESSED_PATH=/uploads/processed
      - FAILED_PATH=/uploads/failed

  file-processor:
    build:
      context: .
      dockerfile: Dockerfile.processor
    volumes:
      - uploads:/uploads
    depends_on:
      - app
    environment:
      - PENDING_PATH=/uploads/pending
      - PROCESSING_PATH=/uploads/processing
      - PROCESSED_PATH=/uploads/processed
      - FAILED_PATH=/uploads/failed
    deploy:
      resources:
        limits:
          memory: 512M
          cpus: '0.5'

volumes:
  uploads:
```

## Test plan

- [x] All file processor compose tests pass
- [x] Full test suite passes
- [x] Template renders correctly with file processor enabled
- [x] Template renders correctly without file processor
- [x] Works with other sidecars (worker, backup, log)

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)