### PR TITLE
feat: implement Jaeger sidecar template for distributed tracing

### DIFF
--- a/internal/generator/compose.go
+++ b/internal/generator/compose.go
@@ -126,6 +126,30 @@ type MetricsSidecarComposeConfig struct {
 	RetentionDays int
 }
 
+// TracingSidecarComposeConfig holds configuration for the Jaeger distributed tracing stack.
+type TracingSidecarComposeConfig struct {
+	// Enabled indicates whether to include the tracing sidecar
+	Enabled bool
+
+	// TracingLibraries is the list of detected tracing libraries
+	TracingLibraries []string
+
+	// TracingProtocol is the detected tracing protocol (otlp, jaeger, zipkin)
+	TracingProtocol string
+
+	// JaegerUIPort is the external port for Jaeger UI (default: 16686)
+	JaegerUIPort int
+
+	// OTLPGRPCPort is the port for OTLP gRPC collector (default: 4317)
+	OTLPGRPCPort int
+
+	// OTLPHTTPPort is the port for OTLP HTTP collector (default: 4318)
+	OTLPHTTPPort int
+
+	// ServiceName is the service name for tracing
+	ServiceName string
+}
+
 // ComposeConfig holds the configuration for generating docker-compose.yml.
 type ComposeConfig struct {
 	// Name is the project name (used for database names, etc.)
@@ -148,6 +172,9 @@ type ComposeConfig struct {
 
 	// MetricsSidecar holds configuration for the Prometheus + Grafana metrics stack
 	MetricsSidecar MetricsSidecarComposeConfig
+
+	// TracingSidecar holds configuration for the Jaeger distributed tracing stack
+	TracingSidecar TracingSidecarComposeConfig
 }
 
 // ComposeGenerator generates docker-compose.yml files.
@@ -291,6 +318,19 @@ func (g *ComposeGenerator) buildConfig(detection *models.Detection, projectName 
 			HasPostgres:      hasPostgres,
 			HasRedis:         hasRedis,
 			RetentionDays:    7,
+		}
+	}
+
+	// Configure tracing sidecar if tracing libraries are detected
+	if detection.NeedsTracing() {
+		config.TracingSidecar = TracingSidecarComposeConfig{
+			Enabled:          true,
+			TracingLibraries: detection.TracingLibraries,
+			TracingProtocol:  detection.GetTracingProtocol(),
+			JaegerUIPort:     16686,
+			OTLPGRPCPort:     4317,
+			OTLPHTTPPort:     4318,
+			ServiceName:      projectName,
 		}
 	}
 

--- a/internal/generator/compose_tracing_integration_test.go
+++ b/internal/generator/compose_tracing_integration_test.go
@@ -1,0 +1,423 @@
+// Package generator provides code generation for devcontainer files.
+package generator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jpequegn/dockstart/internal/models"
+)
+
+func TestComposeConfig_TracingSidecar(t *testing.T) {
+	gen := NewComposeGenerator()
+
+	tests := []struct {
+		name        string
+		detection   *models.Detection
+		checkConfig func(*testing.T, *ComposeConfig)
+	}{
+		{
+			name: "tracing library enables tracing sidecar",
+			detection: &models.Detection{
+				Language:         "nodejs",
+				TracingLibraries: []string{"@opentelemetry/sdk-node"},
+				TracingProtocol:  "otlp",
+			},
+			checkConfig: func(t *testing.T, config *ComposeConfig) {
+				if !config.TracingSidecar.Enabled {
+					t.Error("TracingSidecar.Enabled should be true when tracing libraries detected")
+				}
+				if config.TracingSidecar.TracingProtocol != "otlp" {
+					t.Errorf("TracingSidecar.TracingProtocol = %q, want otlp", config.TracingSidecar.TracingProtocol)
+				}
+				if config.TracingSidecar.JaegerUIPort != 16686 {
+					t.Errorf("TracingSidecar.JaegerUIPort = %d, want 16686", config.TracingSidecar.JaegerUIPort)
+				}
+				if config.TracingSidecar.OTLPGRPCPort != 4317 {
+					t.Errorf("TracingSidecar.OTLPGRPCPort = %d, want 4317", config.TracingSidecar.OTLPGRPCPort)
+				}
+				if config.TracingSidecar.OTLPHTTPPort != 4318 {
+					t.Errorf("TracingSidecar.OTLPHTTPPort = %d, want 4318", config.TracingSidecar.OTLPHTTPPort)
+				}
+			},
+		},
+		{
+			name: "no tracing library disables tracing sidecar",
+			detection: &models.Detection{
+				Language:         "nodejs",
+				TracingLibraries: nil,
+			},
+			checkConfig: func(t *testing.T, config *ComposeConfig) {
+				if config.TracingSidecar.Enabled {
+					t.Error("TracingSidecar.Enabled should be false when no tracing libraries detected")
+				}
+			},
+		},
+		{
+			name: "uses default protocol when unknown",
+			detection: &models.Detection{
+				Language:         "nodejs",
+				TracingLibraries: []string{"@opentelemetry/sdk-node"},
+				TracingProtocol:  "unknown",
+			},
+			checkConfig: func(t *testing.T, config *ComposeConfig) {
+				if !config.TracingSidecar.Enabled {
+					t.Error("TracingSidecar.Enabled should be true")
+				}
+				if config.TracingSidecar.TracingProtocol != "otlp" {
+					t.Errorf("TracingSidecar.TracingProtocol = %q, want otlp (should default)", config.TracingSidecar.TracingProtocol)
+				}
+			},
+		},
+		{
+			name: "preserves jaeger protocol",
+			detection: &models.Detection{
+				Language:         "go",
+				TracingLibraries: []string{"github.com/uber/jaeger-client-go"},
+				TracingProtocol:  "jaeger",
+			},
+			checkConfig: func(t *testing.T, config *ComposeConfig) {
+				if config.TracingSidecar.TracingProtocol != "jaeger" {
+					t.Errorf("TracingSidecar.TracingProtocol = %q, want jaeger", config.TracingSidecar.TracingProtocol)
+				}
+			},
+		},
+		{
+			name: "sets service name from project name",
+			detection: &models.Detection{
+				Language:         "python",
+				TracingLibraries: []string{"opentelemetry-sdk"},
+				TracingProtocol:  "otlp",
+			},
+			checkConfig: func(t *testing.T, config *ComposeConfig) {
+				if config.TracingSidecar.ServiceName != "myproject" {
+					t.Errorf("TracingSidecar.ServiceName = %q, want myproject", config.TracingSidecar.ServiceName)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := gen.buildConfig(tt.detection, "myproject")
+			tt.checkConfig(t, config)
+		})
+	}
+}
+
+func TestComposeGenerator_TracingServices(t *testing.T) {
+	gen := NewComposeGenerator()
+
+	tests := []struct {
+		name            string
+		detection       *models.Detection
+		expectedParts   []string
+		unexpectedParts []string
+	}{
+		{
+			name: "tracing enabled generates jaeger",
+			detection: &models.Detection{
+				Language:         "nodejs",
+				TracingLibraries: []string{"@opentelemetry/sdk-node"},
+				TracingProtocol:  "otlp",
+			},
+			expectedParts: []string{
+				"jaeger:",
+				"image: jaegertracing/all-in-one:latest",
+				"COLLECTOR_OTLP_ENABLED=true",
+				"16686:16686",
+				"4317:4317",
+				"4318:4318",
+				"OTEL_SERVICE_NAME=testproject",
+				"OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318",
+				"OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf",
+				"OTEL_TRACES_SAMPLER=always_on",
+			},
+		},
+		{
+			name: "no tracing libraries no jaeger",
+			detection: &models.Detection{
+				Language: "nodejs",
+			},
+			unexpectedParts: []string{
+				"jaeger:",
+				"OTEL_SERVICE_NAME",
+				"OTEL_EXPORTER_OTLP_ENDPOINT",
+			},
+		},
+		{
+			name: "tracing with worker adds OTEL env to worker",
+			detection: &models.Detection{
+				Language:         "nodejs",
+				TracingLibraries: []string{"@opentelemetry/sdk-node"},
+				TracingProtocol:  "otlp",
+				QueueLibraries:   []string{"bull"},
+				WorkerCommand:    "npm run worker",
+			},
+			expectedParts: []string{
+				"jaeger:",
+				"OTEL_SERVICE_NAME=testproject",
+				"OTEL_SERVICE_NAME=testproject-worker",
+			},
+		},
+		{
+			name: "jaeger healthcheck configured",
+			detection: &models.Detection{
+				Language:         "nodejs",
+				TracingLibraries: []string{"@opentelemetry/sdk-node"},
+			},
+			expectedParts: []string{
+				"healthcheck:",
+				"wget",
+				"http://localhost:16686",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content, err := gen.GenerateContent(tt.detection, "testproject")
+			if err != nil {
+				t.Fatalf("GenerateContent() error = %v", err)
+			}
+
+			contentStr := string(content)
+
+			for _, part := range tt.expectedParts {
+				if !strings.Contains(contentStr, part) {
+					t.Errorf("GenerateContent() missing expected content: %q", part)
+				}
+			}
+
+			for _, part := range tt.unexpectedParts {
+				if strings.Contains(contentStr, part) {
+					t.Errorf("GenerateContent() contains unexpected content: %q", part)
+				}
+			}
+		})
+	}
+}
+
+func TestDevcontainerGenerator_TracingPorts(t *testing.T) {
+	gen := NewDevcontainerGenerator()
+
+	tests := []struct {
+		name        string
+		detection   *models.Detection
+		expectPorts []int
+	}{
+		{
+			name: "tracing adds jaeger UI port",
+			detection: &models.Detection{
+				Language:         "node",
+				Version:          "20",
+				TracingLibraries: []string{"@opentelemetry/sdk-node"},
+			},
+			expectPorts: []int{3000, 16686}, // app + jaeger UI
+		},
+		{
+			name: "no tracing no jaeger port",
+			detection: &models.Detection{
+				Language: "node",
+				Version:  "20",
+			},
+			expectPorts: []int{3000}, // just app
+		},
+		{
+			name: "tracing with metrics adds all ports",
+			detection: &models.Detection{
+				Language:         "node",
+				Version:          "20",
+				TracingLibraries: []string{"@opentelemetry/sdk-node"},
+				MetricsLibraries: []string{"prom-client"},
+			},
+			expectPorts: []int{3000, 9090, 3001, 16686}, // app + prometheus + grafana + jaeger UI
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := gen.buildConfig(tt.detection, "testproject")
+
+			for _, port := range tt.expectPorts {
+				found := false
+				for _, p := range config.ForwardPorts {
+					if p == port {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("Expected port %d not found in ForwardPorts: %v", port, config.ForwardPorts)
+				}
+			}
+		})
+	}
+}
+
+func TestDevcontainerGenerator_UseComposeWithTracing(t *testing.T) {
+	gen := NewDevcontainerGenerator()
+
+	tests := []struct {
+		name             string
+		detection        *models.Detection
+		expectUseCompose bool
+	}{
+		{
+			name: "tracing enables compose",
+			detection: &models.Detection{
+				Language:         "node",
+				Version:          "20",
+				TracingLibraries: []string{"@opentelemetry/sdk-node"},
+			},
+			expectUseCompose: true,
+		},
+		{
+			name: "no sidecars no compose",
+			detection: &models.Detection{
+				Language: "node",
+				Version:  "20",
+			},
+			expectUseCompose: false,
+		},
+		{
+			name: "tracing and metrics enable compose",
+			detection: &models.Detection{
+				Language:         "node",
+				Version:          "20",
+				TracingLibraries: []string{"@opentelemetry/sdk-node"},
+				MetricsLibraries: []string{"prom-client"},
+			},
+			expectUseCompose: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := gen.buildConfig(tt.detection, "testproject")
+
+			if config.UseCompose != tt.expectUseCompose {
+				t.Errorf("UseCompose = %v, want %v", config.UseCompose, tt.expectUseCompose)
+			}
+		})
+	}
+}
+
+func TestTracingWithAllLanguages(t *testing.T) {
+	gen := NewComposeGenerator()
+
+	tests := []struct {
+		name      string
+		detection *models.Detection
+	}{
+		{
+			name: "nodejs with opentelemetry",
+			detection: &models.Detection{
+				Language:         "nodejs",
+				TracingLibraries: []string{"@opentelemetry/sdk-node"},
+				TracingProtocol:  "otlp",
+			},
+		},
+		{
+			name: "go with opentelemetry",
+			detection: &models.Detection{
+				Language:         "go",
+				TracingLibraries: []string{"go.opentelemetry.io/otel"},
+				TracingProtocol:  "otlp",
+			},
+		},
+		{
+			name: "python with opentelemetry",
+			detection: &models.Detection{
+				Language:         "python",
+				TracingLibraries: []string{"opentelemetry-sdk"},
+				TracingProtocol:  "otlp",
+			},
+		},
+		{
+			name: "rust with opentelemetry",
+			detection: &models.Detection{
+				Language:         "rust",
+				TracingLibraries: []string{"opentelemetry"},
+				TracingProtocol:  "otlp",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content, err := gen.GenerateContent(tt.detection, "testproject")
+			if err != nil {
+				t.Fatalf("GenerateContent() error = %v", err)
+			}
+
+			contentStr := string(content)
+			requiredParts := []string{
+				"jaeger:",
+				"jaegertracing/all-in-one:latest",
+				"OTEL_SERVICE_NAME=testproject",
+				"OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318",
+			}
+
+			for _, part := range requiredParts {
+				if !strings.Contains(contentStr, part) {
+					t.Errorf("GenerateContent() for %s missing expected content: %q", tt.name, part)
+				}
+			}
+		})
+	}
+}
+
+func TestTracingCombinedWithOtherSidecars(t *testing.T) {
+	gen := NewComposeGenerator()
+
+	// Full stack detection with tracing, metrics, logging, worker, and services
+	detection := &models.Detection{
+		Language:         "nodejs",
+		Version:          "20",
+		TracingLibraries: []string{"@opentelemetry/sdk-node"},
+		TracingProtocol:  "otlp",
+		MetricsLibraries: []string{"prom-client"},
+		MetricsPort:      3000,
+		MetricsPath:      "/metrics",
+		LoggingLibraries: []string{"pino"},
+		LogFormat:        "json",
+		QueueLibraries:   []string{"bull"},
+		WorkerCommand:    "npm run worker",
+		Services:         []string{"postgres", "redis"},
+	}
+
+	content, err := gen.GenerateContent(detection, "fullstack")
+	if err != nil {
+		t.Fatalf("GenerateContent() error = %v", err)
+	}
+
+	contentStr := string(content)
+	requiredParts := []string{
+		// Tracing
+		"jaeger:",
+		"OTEL_SERVICE_NAME=fullstack",
+		"OTEL_SERVICE_NAME=fullstack-worker",
+		// Metrics
+		"prometheus:",
+		"grafana:",
+		"prometheus.scrape=true",
+		// Logging
+		"fluent-bit:",
+		// Worker
+		"worker:",
+		"npm run worker",
+		// Services
+		"postgres:",
+		"redis:",
+		// Volumes
+		"prometheus-data:",
+		"grafana-data:",
+	}
+
+	for _, part := range requiredParts {
+		if !strings.Contains(contentStr, part) {
+			t.Errorf("Full stack GenerateContent() missing expected content: %q", part)
+		}
+	}
+}

--- a/internal/generator/devcontainer.go
+++ b/internal/generator/devcontainer.go
@@ -81,9 +81,10 @@ func (g *DevcontainerGenerator) buildConfig(detection *models.Detection, project
 		RemoteUser: "root", // Default, will be overridden per language
 	}
 
-	// Determine if we need docker-compose (when services, sidecars, or metrics detected)
+	// Determine if we need docker-compose (when services, sidecars, metrics, or tracing detected)
 	config.UseCompose = len(detection.Services) > 0 || detection.HasStructuredLogging() ||
-		detection.NeedsMetrics() || detection.NeedsWorker() || detection.NeedsFileProcessor()
+		detection.NeedsMetrics() || detection.NeedsWorker() || detection.NeedsFileProcessor() ||
+		detection.NeedsTracing()
 
 	// Language-specific configuration
 	switch detection.Language {
@@ -148,6 +149,11 @@ func (g *DevcontainerGenerator) buildConfig(detection *models.Detection, project
 	if detection.NeedsMetrics() {
 		config.ForwardPorts = append(config.ForwardPorts, 9090)  // Prometheus
 		config.ForwardPorts = append(config.ForwardPorts, 3001)  // Grafana
+	}
+
+	// Add Jaeger port if tracing is detected
+	if detection.NeedsTracing() {
+		config.ForwardPorts = append(config.ForwardPorts, 16686) // Jaeger UI
 	}
 
 	return config

--- a/internal/generator/templates/docker-compose.yml.tmpl
+++ b/internal/generator/templates/docker-compose.yml.tmpl
@@ -28,7 +28,7 @@ services:
       - fluent-bit
 {{- end}}
 {{- end}}
-{{- if or .Services .LogSidecar.Enabled .FileProcessorSidecar.Enabled}}
+{{- if or .Services .LogSidecar.Enabled .FileProcessorSidecar.Enabled .TracingSidecar.Enabled}}
     environment:
 {{- range .Services}}
 {{- if eq .Name "postgres"}}
@@ -45,6 +45,13 @@ services:
       - UPLOAD_PATH=/uploads/pending
       - PROCESSED_PATH=/uploads/processed
       - FAILED_PATH=/uploads/failed
+{{- end}}
+{{- if .TracingSidecar.Enabled}}
+      # OpenTelemetry configuration
+      - OTEL_SERVICE_NAME={{.TracingSidecar.ServiceName}}
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318
+      - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+      - OTEL_TRACES_SAMPLER=always_on
 {{- end}}
 {{- end}}
 {{- if .LogSidecar.Enabled}}
@@ -89,6 +96,13 @@ services:
       - UPLOAD_PATH=/uploads/pending
       - PROCESSED_PATH=/uploads/processed
       - FAILED_PATH=/uploads/failed
+{{- end}}
+{{- if $.TracingSidecar.Enabled}}
+      # OpenTelemetry configuration
+      - OTEL_SERVICE_NAME={{$.TracingSidecar.ServiceName}}-worker
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318
+      - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+      - OTEL_TRACES_SAMPLER=always_on
 {{- end}}
     restart: unless-stopped
 {{- if $.LogSidecar.Enabled}}
@@ -232,6 +246,25 @@ services:
       - redis
     restart: unless-stopped
 {{- end}}
+{{- end}}
+{{- if .TracingSidecar.Enabled}}
+
+  # Jaeger distributed tracing (all-in-one)
+  # Collects traces via OTLP protocol
+  jaeger:
+    image: jaegertracing/all-in-one:latest
+    ports:
+      - "{{.TracingSidecar.OTLPGRPCPort}}:4317"   # OTLP gRPC
+      - "{{.TracingSidecar.OTLPHTTPPort}}:4318"   # OTLP HTTP
+      - "{{.TracingSidecar.JaegerUIPort}}:16686"  # Web UI
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:16686"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
 {{- end}}
 {{- if or .Services .LogSidecar.Enabled .BackupSidecar.Enabled .FileProcessorSidecar.Enabled .MetricsSidecar.Enabled}}
 

--- a/internal/generator/tracing_sidecar.go
+++ b/internal/generator/tracing_sidecar.go
@@ -1,0 +1,104 @@
+// Package generator provides code generation for devcontainer files.
+package generator
+
+import (
+	"github.com/jpequegn/dockstart/internal/models"
+)
+
+// TracingSidecarConfig holds configuration for generating Jaeger tracing sidecar.
+type TracingSidecarConfig struct {
+	// ProjectName is the name of the project
+	ProjectName string
+
+	// Language is the detected programming language
+	Language string
+
+	// TracingProtocol is the detected tracing protocol (otlp, jaeger, zipkin)
+	TracingProtocol string
+
+	// TracingLibraries is the list of detected tracing libraries
+	TracingLibraries []string
+
+	// JaegerUIPort is the port for the Jaeger UI (default: 16686)
+	JaegerUIPort int
+
+	// OTLPGRPCPort is the port for OTLP gRPC collector (default: 4317)
+	OTLPGRPCPort int
+
+	// OTLPHTTPPort is the port for OTLP HTTP collector (default: 4318)
+	OTLPHTTPPort int
+
+	// JaegerAgentPort is the port for Jaeger agent (default: 6831)
+	JaegerAgentPort int
+
+	// MaxTraces is the maximum number of traces to keep in memory (default: 10000)
+	MaxTraces int
+
+	// SamplingRate is the trace sampling rate 0.0-1.0 (default: 1.0 for dev)
+	SamplingRate float64
+}
+
+// DefaultTracingConfig returns a TracingSidecarConfig with sensible defaults.
+func DefaultTracingConfig() *TracingSidecarConfig {
+	return &TracingSidecarConfig{
+		TracingProtocol: "otlp",
+		JaegerUIPort:    16686,
+		OTLPGRPCPort:    4317,
+		OTLPHTTPPort:    4318,
+		JaegerAgentPort: 6831,
+		MaxTraces:       10000,
+		SamplingRate:    1.0, // 100% sampling for development
+	}
+}
+
+// TracingSidecarGenerator generates Jaeger configuration for docker-compose.
+type TracingSidecarGenerator struct{}
+
+// NewTracingSidecarGenerator creates a new tracing sidecar generator.
+func NewTracingSidecarGenerator() *TracingSidecarGenerator {
+	return &TracingSidecarGenerator{}
+}
+
+// BuildConfig creates a TracingSidecarConfig from detection results.
+func (g *TracingSidecarGenerator) BuildConfig(detection *models.Detection, projectName string) *TracingSidecarConfig {
+	config := DefaultTracingConfig()
+	config.ProjectName = projectName
+	config.Language = detection.Language
+	config.TracingLibraries = detection.TracingLibraries
+
+	// Use detected protocol or default to OTLP
+	if detection.TracingProtocol != "" && detection.TracingProtocol != "unknown" {
+		config.TracingProtocol = detection.TracingProtocol
+	}
+
+	return config
+}
+
+// ShouldGenerate returns true if tracing sidecar should be generated.
+func (g *TracingSidecarGenerator) ShouldGenerate(detection *models.Detection) bool {
+	return detection.NeedsTracing()
+}
+
+// GetOTLPEndpoint returns the OTLP endpoint URL for the given protocol preference.
+func (c *TracingSidecarConfig) GetOTLPEndpoint() string {
+	// OTLP HTTP endpoint (used by default for most SDKs)
+	return "http://jaeger:4318"
+}
+
+// GetOTLPProtocol returns the OTLP protocol string.
+func (c *TracingSidecarConfig) GetOTLPProtocol() string {
+	return "http/protobuf"
+}
+
+// GetSamplerType returns the OTEL sampler type.
+func (c *TracingSidecarConfig) GetSamplerType() string {
+	if c.SamplingRate >= 1.0 {
+		return "always_on"
+	}
+	return "parentbased_traceidratio"
+}
+
+// NeedsJaegerEnv returns true if legacy Jaeger environment variables are needed.
+func (c *TracingSidecarConfig) NeedsJaegerEnv() bool {
+	return c.TracingProtocol == "jaeger"
+}

--- a/internal/generator/tracing_sidecar_test.go
+++ b/internal/generator/tracing_sidecar_test.go
@@ -1,0 +1,375 @@
+// Package generator provides code generation for devcontainer files.
+package generator
+
+import (
+	"testing"
+
+	"github.com/jpequegn/dockstart/internal/models"
+)
+
+func TestDefaultTracingConfig(t *testing.T) {
+	config := DefaultTracingConfig()
+
+	tests := []struct {
+		name     string
+		got      interface{}
+		expected interface{}
+	}{
+		{"TracingProtocol", config.TracingProtocol, "otlp"},
+		{"JaegerUIPort", config.JaegerUIPort, 16686},
+		{"OTLPGRPCPort", config.OTLPGRPCPort, 4317},
+		{"OTLPHTTPPort", config.OTLPHTTPPort, 4318},
+		{"JaegerAgentPort", config.JaegerAgentPort, 6831},
+		{"MaxTraces", config.MaxTraces, 10000},
+		{"SamplingRate", config.SamplingRate, 1.0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.expected {
+				t.Errorf("DefaultTracingConfig().%s = %v, want %v", tt.name, tt.got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestTracingSidecarGenerator_ShouldGenerate(t *testing.T) {
+	gen := NewTracingSidecarGenerator()
+
+	tests := []struct {
+		name      string
+		detection *models.Detection
+		expected  bool
+	}{
+		{
+			name: "with tracing library",
+			detection: &models.Detection{
+				Language:         "nodejs",
+				TracingLibraries: []string{"@opentelemetry/sdk-node"},
+			},
+			expected: true,
+		},
+		{
+			name: "without tracing library",
+			detection: &models.Detection{
+				Language:         "nodejs",
+				TracingLibraries: nil,
+			},
+			expected: false,
+		},
+		{
+			name: "empty tracing library slice",
+			detection: &models.Detection{
+				Language:         "go",
+				TracingLibraries: []string{},
+			},
+			expected: false,
+		},
+		{
+			name: "multiple tracing libraries",
+			detection: &models.Detection{
+				Language:         "go",
+				TracingLibraries: []string{"go.opentelemetry.io/otel", "go.opentelemetry.io/otel/exporters/otlp/otlptrace"},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := gen.ShouldGenerate(tt.detection)
+			if result != tt.expected {
+				t.Errorf("ShouldGenerate() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestTracingSidecarGenerator_BuildConfig(t *testing.T) {
+	gen := NewTracingSidecarGenerator()
+
+	tests := []struct {
+		name        string
+		detection   *models.Detection
+		projectName string
+		checkConfig func(*testing.T, *TracingSidecarConfig)
+	}{
+		{
+			name: "uses detection values",
+			detection: &models.Detection{
+				Language:         "nodejs",
+				TracingLibraries: []string{"@opentelemetry/sdk-node"},
+				TracingProtocol:  "otlp",
+			},
+			projectName: "myproject",
+			checkConfig: func(t *testing.T, config *TracingSidecarConfig) {
+				if config.ProjectName != "myproject" {
+					t.Errorf("ProjectName = %q, want %q", config.ProjectName, "myproject")
+				}
+				if config.Language != "nodejs" {
+					t.Errorf("Language = %q, want %q", config.Language, "nodejs")
+				}
+				if config.TracingProtocol != "otlp" {
+					t.Errorf("TracingProtocol = %q, want %q", config.TracingProtocol, "otlp")
+				}
+			},
+		},
+		{
+			name: "uses default protocol when unknown",
+			detection: &models.Detection{
+				Language:         "go",
+				TracingLibraries: []string{"go.opentelemetry.io/otel"},
+				TracingProtocol:  "unknown",
+			},
+			projectName: "goapp",
+			checkConfig: func(t *testing.T, config *TracingSidecarConfig) {
+				if config.TracingProtocol != "otlp" {
+					t.Errorf("TracingProtocol = %q, want %q (should default to otlp)", config.TracingProtocol, "otlp")
+				}
+			},
+		},
+		{
+			name: "uses default protocol when empty",
+			detection: &models.Detection{
+				Language:         "python",
+				TracingLibraries: []string{"opentelemetry-sdk"},
+				TracingProtocol:  "",
+			},
+			projectName: "pyapp",
+			checkConfig: func(t *testing.T, config *TracingSidecarConfig) {
+				if config.TracingProtocol != "otlp" {
+					t.Errorf("TracingProtocol = %q, want %q (should default to otlp)", config.TracingProtocol, "otlp")
+				}
+			},
+		},
+		{
+			name: "preserves jaeger protocol",
+			detection: &models.Detection{
+				Language:         "rust",
+				TracingLibraries: []string{"opentelemetry-jaeger"},
+				TracingProtocol:  "jaeger",
+			},
+			projectName: "rustapp",
+			checkConfig: func(t *testing.T, config *TracingSidecarConfig) {
+				if config.TracingProtocol != "jaeger" {
+					t.Errorf("TracingProtocol = %q, want %q", config.TracingProtocol, "jaeger")
+				}
+			},
+		},
+		{
+			name: "preserves zipkin protocol",
+			detection: &models.Detection{
+				Language:         "nodejs",
+				TracingLibraries: []string{"zipkin"},
+				TracingProtocol:  "zipkin",
+			},
+			projectName: "zipkinapp",
+			checkConfig: func(t *testing.T, config *TracingSidecarConfig) {
+				if config.TracingProtocol != "zipkin" {
+					t.Errorf("TracingProtocol = %q, want %q", config.TracingProtocol, "zipkin")
+				}
+			},
+		},
+		{
+			name: "stores tracing libraries",
+			detection: &models.Detection{
+				Language:         "nodejs",
+				TracingLibraries: []string{"@opentelemetry/sdk-node", "@opentelemetry/auto-instrumentations-node"},
+				TracingProtocol:  "otlp",
+			},
+			projectName: "multilib",
+			checkConfig: func(t *testing.T, config *TracingSidecarConfig) {
+				if len(config.TracingLibraries) != 2 {
+					t.Errorf("TracingLibraries length = %d, want 2", len(config.TracingLibraries))
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := gen.BuildConfig(tt.detection, tt.projectName)
+			tt.checkConfig(t, config)
+
+			// Always check defaults are set
+			if config.JaegerUIPort != 16686 {
+				t.Errorf("JaegerUIPort = %d, want %d", config.JaegerUIPort, 16686)
+			}
+			if config.OTLPGRPCPort != 4317 {
+				t.Errorf("OTLPGRPCPort = %d, want %d", config.OTLPGRPCPort, 4317)
+			}
+			if config.OTLPHTTPPort != 4318 {
+				t.Errorf("OTLPHTTPPort = %d, want %d", config.OTLPHTTPPort, 4318)
+			}
+			if config.SamplingRate != 1.0 {
+				t.Errorf("SamplingRate = %f, want %f", config.SamplingRate, 1.0)
+			}
+		})
+	}
+}
+
+func TestTracingSidecarConfig_GetOTLPEndpoint(t *testing.T) {
+	config := DefaultTracingConfig()
+	endpoint := config.GetOTLPEndpoint()
+
+	if endpoint != "http://jaeger:4318" {
+		t.Errorf("GetOTLPEndpoint() = %q, want %q", endpoint, "http://jaeger:4318")
+	}
+}
+
+func TestTracingSidecarConfig_GetOTLPProtocol(t *testing.T) {
+	config := DefaultTracingConfig()
+	protocol := config.GetOTLPProtocol()
+
+	if protocol != "http/protobuf" {
+		t.Errorf("GetOTLPProtocol() = %q, want %q", protocol, "http/protobuf")
+	}
+}
+
+func TestTracingSidecarConfig_GetSamplerType(t *testing.T) {
+	tests := []struct {
+		name         string
+		samplingRate float64
+		expected     string
+	}{
+		{
+			name:         "100% sampling",
+			samplingRate: 1.0,
+			expected:     "always_on",
+		},
+		{
+			name:         "greater than 100% sampling",
+			samplingRate: 1.5,
+			expected:     "always_on",
+		},
+		{
+			name:         "50% sampling",
+			samplingRate: 0.5,
+			expected:     "parentbased_traceidratio",
+		},
+		{
+			name:         "0% sampling",
+			samplingRate: 0.0,
+			expected:     "parentbased_traceidratio",
+		},
+		{
+			name:         "99% sampling",
+			samplingRate: 0.99,
+			expected:     "parentbased_traceidratio",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &TracingSidecarConfig{SamplingRate: tt.samplingRate}
+			result := config.GetSamplerType()
+			if result != tt.expected {
+				t.Errorf("GetSamplerType() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestTracingSidecarConfig_NeedsJaegerEnv(t *testing.T) {
+	tests := []struct {
+		name     string
+		protocol string
+		expected bool
+	}{
+		{
+			name:     "OTLP protocol",
+			protocol: "otlp",
+			expected: false,
+		},
+		{
+			name:     "Jaeger protocol",
+			protocol: "jaeger",
+			expected: true,
+		},
+		{
+			name:     "Zipkin protocol",
+			protocol: "zipkin",
+			expected: false,
+		},
+		{
+			name:     "Unknown protocol",
+			protocol: "unknown",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &TracingSidecarConfig{TracingProtocol: tt.protocol}
+			result := config.NeedsJaegerEnv()
+			if result != tt.expected {
+				t.Errorf("NeedsJaegerEnv() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNewTracingSidecarGenerator(t *testing.T) {
+	gen := NewTracingSidecarGenerator()
+	if gen == nil {
+		t.Error("NewTracingSidecarGenerator() returned nil")
+	}
+}
+
+func TestTracingSidecarAllLanguages(t *testing.T) {
+	gen := NewTracingSidecarGenerator()
+
+	tests := []struct {
+		name        string
+		language    string
+		libraries   []string
+		protocol    string
+	}{
+		{
+			name:      "nodejs",
+			language:  "nodejs",
+			libraries: []string{"@opentelemetry/sdk-node"},
+			protocol:  "otlp",
+		},
+		{
+			name:      "go",
+			language:  "go",
+			libraries: []string{"go.opentelemetry.io/otel"},
+			protocol:  "otlp",
+		},
+		{
+			name:      "python",
+			language:  "python",
+			libraries: []string{"opentelemetry-sdk"},
+			protocol:  "otlp",
+		},
+		{
+			name:      "rust",
+			language:  "rust",
+			libraries: []string{"opentelemetry"},
+			protocol:  "otlp",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			detection := &models.Detection{
+				Language:         tt.language,
+				TracingLibraries: tt.libraries,
+				TracingProtocol:  tt.protocol,
+			}
+
+			if !gen.ShouldGenerate(detection) {
+				t.Error("ShouldGenerate() should return true for language with tracing")
+			}
+
+			config := gen.BuildConfig(detection, "testproject")
+			if config.Language != tt.language {
+				t.Errorf("Language = %q, want %q", config.Language, tt.language)
+			}
+			if config.TracingProtocol != tt.protocol {
+				t.Errorf("TracingProtocol = %q, want %q", config.TracingProtocol, tt.protocol)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Implements the Jaeger sidecar template for distributed tracing as specified in issue #66. When tracing libraries are detected (from PR #98), dockstart now automatically generates a Jaeger all-in-one container in docker-compose.yml with proper OTEL configuration.

**Key changes:**
- Add `TracingSidecarConfig` with OTLP ports, Jaeger UI port, and sampling configuration
- Add `TracingSidecarComposeConfig` for docker-compose integration
- Generate Jaeger service in docker-compose template with OTLP collector enabled
- Inject OTEL environment variables (`OTEL_SERVICE_NAME`, `OTEL_EXPORTER_OTLP_ENDPOINT`, etc.) into app and worker services
- Add Jaeger UI port (16686) to devcontainer forwarded ports
- Comprehensive unit tests for TracingSidecarGenerator
- Integration tests for compose and devcontainer generation

**Generated docker-compose service:**
```yaml
jaeger:
  image: jaegertracing/all-in-one:latest
  ports:
    - "4317:4317"   # OTLP gRPC
    - "4318:4318"   # OTLP HTTP  
    - "16686:16686" # Web UI
  environment:
    - COLLECTOR_OTLP_ENABLED=true
  healthcheck:
    test: ["CMD", "wget", "--spider", "-q", "http://localhost:16686"]
```

**Environment variables injected into app/worker:**
```yaml
- OTEL_SERVICE_NAME=myproject
- OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318
- OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
- OTEL_TRACES_SAMPLER=always_on
```

Closes #66

## Test plan
- [x] All existing tests pass
- [x] New unit tests for TracingSidecarConfig and TracingSidecarGenerator
- [x] Integration tests for compose template generation with tracing
- [x] Integration tests for devcontainer port forwarding
- [x] Full stack test combining tracing with metrics, logging, and worker sidecars

🤖 Generated with [Claude Code](https://claude.com/claude-code)