### PR TITLE
Update compose generator for tracing sidecar (#67)

### DIFF
--- a/docs/adr/001-distributed-tracing-sidecar.md
+++ b/docs/adr/001-distributed-tracing-sidecar.md
@@ -1,0 +1,55 @@
+# ADR 001: Distributed Tracing Sidecar Architecture
+
+## Status
+Proposed
+
+## Context
+Dockstart aims to provide a "one-click" development environment setup. Distributed tracing is essential for modern microservices and complex applications to debug performance issues and understand request flows. We need to define how to integrate Jaeger as a sidecar/service in the generated `docker-compose.yml` and how to configure the application to send traces.
+
+## Decision
+We will implement the Distributed Tracing Sidecar using the following architectural decisions:
+
+1.  **Protocol**: Default to **OTLP (OpenTelemetry Protocol) over HTTP (port 4318)**.
+    *   *Rationale*: OTLP is the vendor-agnostic industry standard. While Jaeger has native protocols, OTLP ensures compatibility with most modern SDKs and future-proofs the implementation. HTTP is chosen over gRPC for better compatibility with varied environments (e.g., browsers, restricted networks).
+2.  **Jaeger Deployment**: Use **Jaeger All-in-One** (`jaegertracing/all-in-one`).
+    *   *Rationale*: Dockstart targets development environments. All-in-one is easy to set up, requires minimal resources, and includes the UI, collector, and query service in a single container.
+3.  **Storage**: **In-memory**.
+    *   *Rationale*: Persistence is not required for typical development sessions. In-memory storage simplifies the setup by removing the need for external databases like Elasticsearch or Cassandra.
+4.  **Sampling Strategy**: **100% (Always On)**.
+    *   *Rationale*: In a development context, developers usually want to see every trace for the specific scenarios they are testing. Performance overhead is negligible for dev workloads.
+5.  **Configuration Method**: **Environment Variables**.
+    *   *Rationale*: Environment variables are the standard way to configure OpenTelemetry SDKs and are easily injected via `docker-compose.yml`.
+
+## Technical Specification
+
+### Jaeger Service Configuration
+The following ports will be exposed by the Jaeger container:
+- `16686`: Jaeger UI (HTTP)
+- `4317`: OTLP gRPC receiver
+- `4318`: OTLP HTTP receiver
+
+### Injected Environment Variables
+For the application service:
+- `OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318`
+- `OTEL_SERVICE_NAME={{.ProjectName}}`
+- `OTEL_TRACES_SAMPLER=always_on`
+
+## Architecture Diagram
+```mermaid
+graph LR
+    App[Application Service] -- OTLP/HTTP (4318) --> Jaeger[Jaeger All-in-One]
+    Developer -- Browser (16686) --> Jaeger
+    Jaeger -- In-Memory --> Storage[(Transient Storage)]
+```
+
+### Legacy Support (Optional/Secondary)
+We will maintain the possibility to enable Jaeger Thrift (port `14268`) if specifically requested, but it won't be the default.
+
+## Consequences
+- **Pros**:
+    - Standardization on OTLP.
+    - Simplified development workflow with all-in-one Jaeger.
+    - Zero-config required for applications using standard OTLP SDKs.
+- **Cons**:
+    - In-memory storage means traces are lost on container restart.
+    - All-in-one is not suitable for high-load production-like testing.

--- a/docs/tracing-research.md
+++ b/docs/tracing-research.md
@@ -1,0 +1,49 @@
+# Research Report: Distributed Tracing Sidecar
+
+## Overview
+This report summarizes the research conducted for implementing a distributed tracing sidecar in Dockstart, focusing on Jaeger and OpenTelemetry (OTEL).
+
+## Protocol Selection: OTLP vs. Jaeger Native
+After evaluating both options, **OTLP (OpenTelemetry Protocol)** is recommended as the primary protocol.
+
+| Feature | OTLP | Jaeger Native (Thrift) |
+|---------|------|------------------------|
+| Standard | Industry Standard (CNCF) | Project Specific |
+| Portability | High (works with any backend) | Low (Jaeger specific) |
+| Future-proof | Yes | Legacy/Maintenance |
+| SDK Support | Excellent | Diminishing |
+
+**Recommendation**: Default to OTLP over HTTP (`4318`) for maximum compatibility.
+
+## Deployment Mode: All-in-One vs. Production
+For the scope of Dockstart (development environments), **Jaeger All-in-One** is the superior choice.
+
+- **All-in-One**: Combines agent, collector, query, and UI. Uses in-memory storage. Ideal for single-node dev environments.
+- **Production**: Distributed architecture using Kafka, Elasticsearch/Cassandra. Overkill for local development.
+
+## Sampling Strategy
+In development, we recommend **100% sampling** (`always_on`).
+- **Why?** Developers need to see the results of their specific actions. Probabilistic sampling can lead to frustration when a specific request isn't captured during debugging.
+
+## Trace Context Propagation
+Context propagation (e.g., `traceparent` headers) is handled by the application's SDK. Dockstart's role is to ensure the `OTEL_SERVICE_NAME` and `OTEL_EXPORTER_OTLP_ENDPOINT` are correctly set so the SDK knows where to send the spans.
+
+## Environment Variable Guide
+To enable tracing in a Dockstart-enabled project, the following environment variables should be injected:
+
+```yaml
+services:
+  app:
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318
+      - OTEL_SERVICE_NAME=my-service
+      - OTEL_TRACES_SAMPLER=always_on
+```
+
+## Architecture Diagram (Textual Representation)
+```mermaid
+graph LR
+    App[Application Service] -- OTLP/HTTP (4318) --> Jaeger[Jaeger All-in-One]
+    Developer -- Browser (16686) --> Jaeger
+    Jaeger -- In-Memory --> Storage[(Transient Storage)]
+```

--- a/internal/generator/compose.go
+++ b/internal/generator/compose.go
@@ -146,6 +146,15 @@ type TracingSidecarComposeConfig struct {
 	// OTLPHTTPPort is the port for OTLP HTTP collector (default: 4318)
 	OTLPHTTPPort int
 
+	// OTLPProtocol is the OTLP protocol format (default: http/protobuf)
+	OTLPProtocol string
+
+	// OTLPSampler is the OTLP sampler configuration (default: always_on)
+	OTLPSampler string
+
+	// MaxTraces is the maximum number of traces in memory (default: 10000)
+	MaxTraces int
+
 	// ServiceName is the service name for tracing
 	ServiceName string
 }
@@ -330,6 +339,9 @@ func (g *ComposeGenerator) buildConfig(detection *models.Detection, projectName 
 			JaegerUIPort:     16686,
 			OTLPGRPCPort:     4317,
 			OTLPHTTPPort:     4318,
+			OTLPProtocol:     "http/protobuf",
+			OTLPSampler:      "always_on",
+			MaxTraces:        10000,
 			ServiceName:      projectName,
 		}
 	}

--- a/internal/generator/templates/docker-compose.yml.tmpl
+++ b/internal/generator/templates/docker-compose.yml.tmpl
@@ -19,13 +19,17 @@ services:
       - "prometheus.port={{.MetricsSidecar.MetricsPort}}"
       - "prometheus.path={{.MetricsSidecar.MetricsPath}}"
 {{- end}}
-{{- if or .Services .LogSidecar.Enabled}}
+{{- if or .Services .LogSidecar.Enabled .TracingSidecar.Enabled}}
     depends_on:
 {{- range .Services}}
       - {{.Name}}
 {{- end}}
 {{- if .LogSidecar.Enabled}}
       - fluent-bit
+{{- end}}
+{{- if .TracingSidecar.Enabled}}
+      jaeger:
+        condition: service_healthy
 {{- end}}
 {{- end}}
 {{- if or .Services .LogSidecar.Enabled .FileProcessorSidecar.Enabled .TracingSidecar.Enabled}}
@@ -49,9 +53,9 @@ services:
 {{- if .TracingSidecar.Enabled}}
       # OpenTelemetry configuration
       - OTEL_SERVICE_NAME={{.TracingSidecar.ServiceName}}
-      - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318
-      - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
-      - OTEL_TRACES_SAMPLER=always_on
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:{{.TracingSidecar.OTLPHTTPPort}}
+      - OTEL_EXPORTER_OTLP_PROTOCOL={{.TracingSidecar.OTLPProtocol}}
+      - OTEL_TRACES_SAMPLER={{.TracingSidecar.OTLPSampler}}
 {{- end}}
 {{- end}}
 {{- if .LogSidecar.Enabled}}
@@ -81,6 +85,10 @@ services:
 {{- range .Services}}
       - {{.Name}}
 {{- end}}
+{{- if .TracingSidecar.Enabled}}
+      jaeger:
+        condition: service_healthy
+{{- end}}
     environment:
       - WORKER_CONCURRENCY=2
       - NODE_ENV=development
@@ -100,9 +108,9 @@ services:
 {{- if $.TracingSidecar.Enabled}}
       # OpenTelemetry configuration
       - OTEL_SERVICE_NAME={{$.TracingSidecar.ServiceName}}-worker
-      - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318
-      - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
-      - OTEL_TRACES_SAMPLER=always_on
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:{{$.TracingSidecar.OTLPHTTPPort}}
+      - OTEL_EXPORTER_OTLP_PROTOCOL={{$.TracingSidecar.OTLPProtocol}}
+      - OTEL_TRACES_SAMPLER={{$.TracingSidecar.OTLPSampler}}
 {{- end}}
     restart: unless-stopped
 {{- if $.LogSidecar.Enabled}}
@@ -259,10 +267,12 @@ services:
       - "{{.TracingSidecar.JaegerUIPort}}:16686"  # Web UI
     environment:
       - COLLECTOR_OTLP_ENABLED=true
+      - SPAN_STORAGE_TYPE=memory
+      - MEMORY_MAX_TRACES={{.TracingSidecar.MaxTraces}}
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:16686"]
-      interval: 10s
-      timeout: 5s
+      interval: 5s
+      timeout: 3s
       retries: 3
     restart: unless-stopped
 {{- end}}


### PR DESCRIPTION
This PR completes the implementation of the Jaeger distributed tracing sidecar in the compose generator.

### Changes:
- Extended `TracingSidecarComposeConfig` with configurable OTLP settings:
    - `OTLPProtocol`: Default `http/protobuf`
    - `OTLPSampler`: Default `always_on` (100% sampling for dev)
    - `MaxTraces`: Default 10000 (memory limit)
- Updated `docker-compose.yml.tmpl`:
    - Jaeger service now uses in-memory storage (`SPAN_STORAGE_TYPE=memory`)
    - Configurable memory limit via `MEMORY_MAX_TRACES`
    - Health check with 5s interval and 3s timeout
    - `app` service depends on Jaeger being healthy
    - `worker` service depends on Jaeger being healthy
    - Environment variables injected into both `app` and `worker`
- Port forwarding for Jaeger UI (16686) already implemented in devcontainer.json

### Generated Output Example:
```yaml
services:
  app:
    depends_on:
      jaeger:
        condition: service_healthy
    environment:
      - OTEL_SERVICE_NAME=my-api
      - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318
      - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
      - OTEL_TRACES_SAMPLER=always_on

  jaeger:
    image: jaegertracing/all-in-one:latest
    ports:
      - "4317:4317"
      - "4318:4318"
      - "16686:16686"
    environment:
      - COLLECTOR_OTLP_ENABLED=true
      - SPAN_STORAGE_TYPE=memory
      - MEMORY_MAX_TRACES=10000
    healthcheck:
      test: ["CMD", "wget", "--spider", "-q", "http://localhost:16686"]
      interval: 5s
      timeout: 3s
      retries: 3
```

Closes #67